### PR TITLE
fix: Fix re-start issue when using built-in nacos

### DIFF
--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -19,4 +19,5 @@ ROOT=$(dirname -- "$(pwd -P)")
 COMPOSE_ROOT="$ROOT/compose"
 cd - > /dev/null
 
-cd "$COMPOSE_ROOT" && docker compose -p higress down --remove-orphans
+source $COMPOSE_ROOT/.env
+cd "$COMPOSE_ROOT" && COMPOSE_PROFILES="$COMPOSE_PROFILES" && docker compose -p higress down --remove-orphans

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -24,6 +24,8 @@ if [ ! -f "$CONFIGURED_MARK" ]; then
   echo "Higress hasn't been configured yet. Please run \"$ROOT/bin/configure.sh\" first"
   exit -1
 fi
+
+source $COMPOSE_ROOT/.env
 cd "$COMPOSE_ROOT" && COMPOSE_PROFILES="$COMPOSE_PROFILES" docker compose -p higress up -d
 
 retVal=$?


### PR DESCRIPTION
Fix the issue that built-in nacos isn't started when manually calling startup.sh.