### PR TITLE
fix: Ignore errors of failed to get access token from nacos

### DIFF
--- a/compose/scripts/init.sh
+++ b/compose/scripts/init.sh
@@ -99,8 +99,9 @@ initializeNacos() {
   if [ -n "$NACOS_USERNAME" ] && [ -n "$NACOS_PASSWORD" ]; then
     NACOS_ACCESS_TOKEN="$(curl -s "${NACOS_SERVER_URL}/v1/auth/login" -X POST --data-urlencode "username=${NACOS_USERNAME}" --data-urlencode "password=${NACOS_PASSWORD}" | jq -rM '.accessToken')";
     if [ -z "$NACOS_ACCESS_TOKEN" ]; then
-      echo "  Unable to retrieve access token from Nacos."
-      exit -1 
+      echo "Unable to retrieve access token from Nacos. Possible causes are:"
+      echo "  1. Incorrect username or password."
+      echo "  2. The target Nacos service doesn't have authentication enabled."
     fi
   fi
 

--- a/compose/scripts/precheck.sh
+++ b/compose/scripts/precheck.sh
@@ -64,8 +64,9 @@ checkNacos() {
     curl -sv "${NACOS_SERVER_URL}/v1/auth/login" -X POST --data-urlencode "username=${NACOS_USERNAME}" --data-urlencode "password=${NACOS_PASSWORD}" 
     NACOS_ACCESS_TOKEN="$(curl -s "${NACOS_SERVER_URL}/v1/auth/login" -X POST --data-urlencode "username=${NACOS_USERNAME}" --data-urlencode "password=${NACOS_PASSWORD}" | jq -rM '.accessToken')";
     if [ -z "$NACOS_ACCESS_TOKEN" ]; then
-      echo "  Unable to retrieve access token from Nacos."
-      exit -1 
+      echo "Unable to retrieve access token from Nacos. Possible causes are:"
+      echo "  1. Incorrect username or password."
+      echo "  2. The target Nacos service doesn't have authentication enabled."
     fi
   fi
 


### PR DESCRIPTION
Reason: Just in case auth isn't enabled in nacos actually and user made a wrong configuration.