### PR TITLE
fix: Fix the malfunction of Wasm plugins

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - serve
       - --kubeconfig=/home/higress/.kube/config
       - --gatewaySelectorKey=higress
-      - --gatewaySelectorValue=higress-gateway
+      - --gatewaySelectorValue=higress-system-higress-gateway
       - --ingressClass=higress
     depends_on:
       apiserver:
@@ -177,6 +177,7 @@ services:
       - ./volumes/pilot/config:/etc/istio/config:ro
       - ./volumes/gateway/certs:/etc/certs:ro
       - ./volumes/gateway/podinfo:/etc/istio/pod:ro
+      - ./volumes/gateway/istio/data:/var/lib/istio/data:rw
 
   console:
     image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console:${HIGRESS_CONSOLE_TAG}

--- a/compose/env/gateway.env
+++ b/compose/env/gateway.env
@@ -2,3 +2,6 @@ JWT_POLICY=none
 CA_ROOT_CA=/etc/certs/root-cert.pem
 XDS_ROOT_CA=/etc/certs/root-cert.pem
 PROV_CERT=/etc/certs
+PROXY_XDS_VIA_AGENT=true
+POD_NAME=higress-gateway
+POD_NAMESPACE=higress-system

--- a/compose/scripts/init.sh
+++ b/compose/scripts/init.sh
@@ -315,7 +315,9 @@ initializeGateway() {
   cp $VOLUMES_ROOT/pilot/cacerts/gateway-key.pem ./key.pem
 
   mkdir -p $VOLUMES_ROOT/gateway/podinfo && cd "$_"
-  echo 'higress="higress-gateway"' > ./labels
+  echo 'higress="higress-system-higress-gateway"' > ./labels
+
+  mkdir -p $VOLUMES_ROOT/gateway/istio/data
 }
 
 initializeMcpBridge() {


### PR DESCRIPTION
1. Selectors in WasmPlugin resources generated by Higress Controller seems to be `namespace.name` at all time. So change the gateway selector labels to meet the requirement.
2. Add POD_NAME and POD_NAMESPACE environment variables to normalize the proxyID values logged by the pilot.
3. Mount a writable volume to `/var/lib/istio/data` in gateway container for storing downloaded Wasm plugins.