### PR TITLE
fix: Fix some bugs in shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker compose
 
     配置服务的 URL。
     - 若使用独立部署的 Nacos 服务，URL 格式为：nacos://192.168.0.1:8848
-    - 若在本地磁盘上保存配置，URL 格式为：file://opt/higress/conf
+    - 若在本地磁盘上保存配置，URL 格式为：file:///opt/higress/conf
 
   * --use-builtin-nacos
 
@@ -71,7 +71,7 @@ docker compose
 
   * -p, --console-password=CONSOLE-PASSWORD
 
-    后续用户访问 Higress Console 的密码（用户名固定为 `admin`）。默认值为 `admin`。
+    后续用户访问 Higress Console 的密码（用户名固定为 `admin`）。若未设置，Higress 将自动生成一个随机的密码。
 
   * --nacos-port=NACOS-PORT
 
@@ -81,7 +81,7 @@ docker compose
 
     Higress Gateway 在服务器本地监听的 HTTP 端口。默认值为 80。
 
-  * --gateway-https-port=GATEAWY-HTTPS-PORT
+  * --gateway-https-port=GATEWAY-HTTPS-PORT
 
     Higress Gateway 在服务器本地监听的 HTTPS 端口。默认值为 443。
 

--- a/src/get-higress.sh
+++ b/src/get-higress.sh
@@ -71,7 +71,7 @@ outputUsage() {
   echo '
  -c, --config-url=URL       URL of the config storage
                             Use Nacos with format: nacos://192.168.0.1:8848
-                            Use local files with format: file://opt/higress/conf
+                            Use local files with format: file:///opt/higress/conf
      --use-builtin-nacos    use the built-in Nacos service instead of
                             an external one
      --nacos-ns=NACOS-NAMESPACE
@@ -190,7 +190,7 @@ download() {
 
 # install installs the product.
 install() {
-  tar -zx --exclude="docs" --exclude="src" -f "$HIGRESS_TMP_FILE" -C "$DESTINATION" --strip-components=1
+  tar -zx --exclude="docs" --exclude="src" --exclude="test" -f "$HIGRESS_TMP_FILE" -C "$DESTINATION" --strip-components=1
   bash "$DESTINATION/bin/configure.sh" --auto-start ${CONFIG_ARGS[@]}
 }
 

--- a/test/configure/cases/args-file-full_non-windows.inc
+++ b/test/configure/cases/args-file-full_non-windows.inc
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file://tmp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
+CONFIGURE_ARGS="-c file:///tmp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
 
 CONFIGURE_INPUT=""
 

--- a/test/configure/cases/args-file-path-relative_non-windows.inc
+++ b/test/configure/cases/args-file-path-relative_non-windows.inc
@@ -12,17 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file:///c/temp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
+CONFIGURE_ARGS="-c file://./higress/data"
 
 CONFIGURE_INPUT=""
 
 declare -A EXPECTED_ENVS=(
   ["COMPOSE_PROFILES"]=''
   ["CONFIG_STORAGE"]='file'
-  ["FILE_ROOT_DIR"]='C:\temp\higress\data'
-  ["HIGRESS_CONSOLE_PASSWORD"]='helloworld'
-  ["GATEWAY_HTTP_PORT"]='30002'
-  ["GATEWAY_HTTPS_PORT"]='30003'
-  ["GATEWAY_METRICS_PORT"]='30004'
-  ["CONSOLE_PORT"]='30005'
+  ["FILE_ROOT_DIR"]="$(pwd)/higress/data"
+  ["GATEWAY_HTTP_PORT"]='80'
+  ["GATEWAY_HTTPS_PORT"]='443'
+  ["GATEWAY_METRICS_PORT"]='15020'
+  ["CONSOLE_PORT"]='8080'
 )

--- a/test/configure/cases/args-file-path-relative_windows.inc
+++ b/test/configure/cases/args-file-path-relative_windows.inc
@@ -12,17 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file:///c/temp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
+CONFIGURE_ARGS="-c file://./higress/data"
 
 CONFIGURE_INPUT=""
 
 declare -A EXPECTED_ENVS=(
   ["COMPOSE_PROFILES"]=''
   ["CONFIG_STORAGE"]='file'
-  ["FILE_ROOT_DIR"]='C:\temp\higress\data'
-  ["HIGRESS_CONSOLE_PASSWORD"]='helloworld'
-  ["GATEWAY_HTTP_PORT"]='30002'
-  ["GATEWAY_HTTPS_PORT"]='30003'
-  ["GATEWAY_METRICS_PORT"]='30004'
-  ["CONSOLE_PORT"]='30005'
+  ["FILE_ROOT_DIR"]="$(cygpath -w "$PWD")\\higress\\data"
+  ["GATEWAY_HTTP_PORT"]='80'
+  ["GATEWAY_HTTPS_PORT"]='443'
+  ["GATEWAY_METRICS_PORT"]='15020'
+  ["CONSOLE_PORT"]='8080'
 )

--- a/test/configure/cases/args-file-path-with-colon_windows.inc
+++ b/test/configure/cases/args-file-path-with-colon_windows.inc
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file://c/temp/higress/data"
+CONFIGURE_ARGS="-c file:///c:/temp/higress/data"
 
 CONFIGURE_INPUT=""
 

--- a/test/configure/cases/input-file-full_non-windows.inc
+++ b/test/configure/cases/input-file-full_non-windows.inc
@@ -17,7 +17,6 @@ CONFIGURE_ARGS=""
 CONFIGURE_INPUT="file
 /tmp/higress/data
 admin
-30001
 30002
 30003
 30004

--- a/test/configure/cases/input-file-relative-path_non-windows.inc
+++ b/test/configure/cases/input-file-relative-path_non-windows.inc
@@ -12,17 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file:///c/temp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
+CONFIGURE_ARGS=""
 
-CONFIGURE_INPUT=""
+CONFIGURE_INPUT='file
+./higress/data
+admin
+
+
+
+
+'
+
+echo "$CONFIGURE_INPUT"
 
 declare -A EXPECTED_ENVS=(
   ["COMPOSE_PROFILES"]=''
   ["CONFIG_STORAGE"]='file'
-  ["FILE_ROOT_DIR"]='C:\temp\higress\data'
-  ["HIGRESS_CONSOLE_PASSWORD"]='helloworld'
-  ["GATEWAY_HTTP_PORT"]='30002'
-  ["GATEWAY_HTTPS_PORT"]='30003'
-  ["GATEWAY_METRICS_PORT"]='30004'
-  ["CONSOLE_PORT"]='30005'
+  ["FILE_ROOT_DIR"]="$(pwd)/higress/data"
+  ["HIGRESS_CONSOLE_PASSWORD"]='admin'
+  ["GATEWAY_HTTP_PORT"]='80'
+  ["GATEWAY_HTTPS_PORT"]='443'
+  ["GATEWAY_METRICS_PORT"]='15020'
+  ["CONSOLE_PORT"]='8080'
 )

--- a/test/configure/cases/input-file-relative-path_windows.inc
+++ b/test/configure/cases/input-file-relative-path_windows.inc
@@ -12,17 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-CONFIGURE_ARGS="-c file:///c/temp/higress/data --console-password=helloworld --gateway-http-port=30002 --gateway-https-port=30003 --gateway-metrics-port=30004 --console-port=30005"
+CONFIGURE_ARGS=""
 
-CONFIGURE_INPUT=""
+CONFIGURE_INPUT='file
+.\temp\data
+admin
+
+
+
+
+'
+
+echo "$CONFIGURE_INPUT"
 
 declare -A EXPECTED_ENVS=(
   ["COMPOSE_PROFILES"]=''
   ["CONFIG_STORAGE"]='file'
-  ["FILE_ROOT_DIR"]='C:\temp\higress\data'
-  ["HIGRESS_CONSOLE_PASSWORD"]='helloworld'
-  ["GATEWAY_HTTP_PORT"]='30002'
-  ["GATEWAY_HTTPS_PORT"]='30003'
-  ["GATEWAY_METRICS_PORT"]='30004'
-  ["CONSOLE_PORT"]='30005'
+  ["FILE_ROOT_DIR"]="$(cygpath -w "$PWD")\\temp\\data"
+  ["HIGRESS_CONSOLE_PASSWORD"]='admin'
+  ["GATEWAY_HTTP_PORT"]='80'
+  ["GATEWAY_HTTPS_PORT"]='443'
+  ["GATEWAY_METRICS_PORT"]='15020'
+  ["CONSOLE_PORT"]='8080'
 )


### PR DESCRIPTION
Fix some bugs in shell scripts:
1. Fix the incorrect format of file:// URLs supported in configuration
    Supported formats: 
    - file:///opt/higress/data
    - file://./higress/data
    - file:///c/temp/higress/data
    - file:///c:/opt/higress/data
2. Always create a default McpBridge resource for editing
3. Exclude the test folder when decompressing during installation