### PR TITLE
fix: Fix the authentication failure one month later after the installation

### DIFF
--- a/compose/scripts/init.sh
+++ b/compose/scripts/init.sh
@@ -180,7 +180,7 @@ initializeApiServer() {
 
   if [ ! -f ca.key ] || [ ! -f ca.crt ]; then
     echo "  Generating CA certificate...";
-    openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=higress-root-ca/O=higress" > /dev/null 2>&1
+    openssl req -nodes -new -x509 -days 36500 -keyout ca.key -out ca.crt -subj "/CN=higress-root-ca/O=higress" > /dev/null 2>&1
     checkExitCode "  Generating CA certificate for API server fails with $?";
   else
     echo "  CA certificate already exists.";
@@ -188,7 +188,7 @@ initializeApiServer() {
   if [ ! -f server.key ] || [ ! -f server.crt ]; then
     echo "  Generating server certificate..."
     openssl req -out server.csr -new -newkey rsa:$RSA_KEY_LENGTH -nodes -keyout server.key -subj "/CN=higress-api-server/O=higress" > /dev/null 2>&1 \
-      && openssl x509 -req -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -sha256 -out server.crt > /dev/null 2>&1
+      && openssl x509 -req -days 36500 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -sha256 -out server.crt > /dev/null 2>&1
     checkExitCode "  Generating server certificate fails with $?";
   else
     echo "  Server certificate already exists.";
@@ -206,7 +206,7 @@ initializeApiServer() {
   if [ ! -f client.key ] || [ ! -f client.crt ]; then
     echo "  Generating client certificate..."
     openssl req -out client.csr -new -newkey rsa:$RSA_KEY_LENGTH -nodes -keyout client.key -subj "/CN=higress/O=system:masters" > /dev/null 2>&1 \
-      && openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 02 -sha256 -out client.crt > /dev/null 2>&1
+      && openssl x509 -req -days 36500 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 02 -sha256 -out client.crt > /dev/null 2>&1
     checkExitCode "  Generating client certificate fails with $?";
   else
     echo "  Client certificate already exists.";

--- a/src/apiserver/Makefile
+++ b/src/apiserver/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/
 IMAGE_NAME ?= api-server
-IMAGE_VERSION ?= 0.0.9
+IMAGE_VERSION ?= 0.0.10
 BUILD_TIME := $(shell date "+%Y%m%d-%H%M%S")
 COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMAGE_TAG = $(if $(strip $(IMAGE_VERSION)),${IMAGE_VERSION},${BUILD_TIME}-${COMMIT_ID})

--- a/src/apiserver/pkg/apiserver/apiserver.go
+++ b/src/apiserver/pkg/apiserver/apiserver.go
@@ -103,6 +103,7 @@ func init() {
 
 // ExtraConfig holds custom apiserver config
 type ExtraConfig struct {
+	AuthOptions    *options.AuthOptions
 	StorageOptions *options.StorageOptions
 }
 

--- a/src/apiserver/pkg/options/options.go
+++ b/src/apiserver/pkg/options/options.go
@@ -20,6 +20,27 @@ const (
 	Storage_Nacos = "nacos"
 )
 
+func CreateAuthOptions() *AuthOptions {
+	return &AuthOptions{}
+}
+
+type AuthOptions struct {
+	Enabled bool
+}
+
+func (o *AuthOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	fs.BoolVar(&o.Enabled, "auth-enabled", false, "Whether to enable authentication and authorization for Higress API server.")
+}
+
+func (o *AuthOptions) Validate() []error {
+	// Nothing to validate for now
+	return []error{}
+}
+
 func CreateStorageOptions() *StorageOptions {
 	return &StorageOptions{
 		FileOptions:  &FileOptions{},


### PR DESCRIPTION
1. Extend the validity of certificates used by API server to 100 years.
2. Disable the authentication and authorization features on API server by default.

Note: After disabling authN and authZ of API server, the validity of cerificates won't matter at all. The validity of 100 years is just in case.