### PR TITLE
fix: No update prompt if the target folder contains an unconfigured Higress instance

### DIFF
--- a/src/get-higress.sh
+++ b/src/get-higress.sh
@@ -55,8 +55,8 @@ parseArgs() {
 
 validateArgs() {
   if [ -d "$DESTINATION" ]; then
-    if [ "$(ls -A "$DESTINATION")" -a "$MODE" != "update" ]; then
-      echo "The target folder \"$DESTINATION\" is not empty. Add \"-u\" to update an existed Higress instance." && exit 1
+    if [ -e "${DESTINATION}/compose/.configured" -a "$MODE" != "update" ]; then
+      echo "Higress is already installed in the target folder \"$DESTINATION\". Add \"-u\" to update an existed Higress instance." && exit 1
     fi
     if [ ! -w "$DESTINATION" ]; then
       echo "The target folder \"$DESTINATION\" is not writeable." && exit 1


### PR DESCRIPTION
If anything goes wrong during the configuration phase of the standalone deployment, and user tries to reinstall Higress, an "update with -u" prompt would be shown.

However, Higress is not in fact "installed" in the target folder. So we use the "compose/.configured" file to determine whether the configuration phase has finished successfully or not, and only show the update prompt if configured.