### PR TITLE
feat: Separate the config workflow into two phases: prepare and init

### DIFF
--- a/bin/reset.sh
+++ b/bin/reset.sh
@@ -20,4 +20,4 @@ COMPOSE_ROOT="$ROOT/compose"
 cd - > /dev/null
 
 bash $ROOT/bin/shutdown.sh
-cd "$COMPOSE_ROOT" && sudo rm -rf ./volumes && rm -f ./.configured
+cd "$COMPOSE_ROOT" && rm -rf ./volumes && rm -f ./.configured

--- a/src/get-higress.sh
+++ b/src/get-higress.sh
@@ -205,7 +205,7 @@ download() {
 install() {
   tar -zx --exclude="docs" --exclude="src" --exclude="test" -f "$HIGRESS_TMP_FILE" -C "$DESTINATION" --strip-components=1
   echo -n "$VERSION" > "$DESTINATION/VERSION"
-  bash "$DESTINATION/bin/configure.sh" --auto-start ${CONFIG_ARGS[@]}
+  bash "$DESTINATION/bin/configure.sh" ${CONFIG_ARGS[@]}
 }
 
 # update updates the product.


### PR DESCRIPTION
Allow separating the config workflow into two phases: prepare and init, so hgctl can know which phase goes wrong and deal the problem properly.