### PR TITLE
fix: Fix some errors in nacosREST

### DIFF
--- a/src/apiserver/pkg/options/options.go
+++ b/src/apiserver/pkg/options/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
 	"net/url"
 	"os"
 	"strconv"
@@ -19,6 +20,18 @@ const (
 	Storage_File  = "file"
 	Storage_Nacos = "nacos"
 )
+
+var (
+	NacosDisableUseSnapShot      = utils.GetBoolFromEnv("NACOS_DISABLE_USE_SNAPSHOT", false)
+	NacosListRefreshIntervalSecs = utils.GetIntFromEnv("NACOS_LIST_REFRESH_INTERVAL_SECS", 10)
+	NacosConfigSearchPageSize    = utils.GetIntFromEnv("NACOS_CONFIG_SEARCH_PAGE_SIZE", 50)
+)
+
+func init() {
+	klog.Infof("NacosDisableUseSnapShot: %v", NacosDisableUseSnapShot)
+	klog.Infof("NacosListRefreshIntervalSecs: %v", NacosListRefreshIntervalSecs)
+	klog.Infof("NacosConfigSearchPageSize: %v", NacosConfigSearchPageSize)
+}
 
 func CreateAuthOptions() *AuthOptions {
 	return &AuthOptions{}
@@ -225,8 +238,7 @@ func (o *NacosOptions) CreateConfigClient() (config_client.IConfigClient, error)
 		constant.WithLogDir(o.LogDir),
 		constant.WithCacheDir(o.CacheDir),
 		constant.WithLogLevel("info"),
-		// Ignore snapshot so we can get the latest config right after making any change.
-		constant.WithDisableUseSnapShot(true),
+		constant.WithDisableUseSnapShot(NacosDisableUseSnapShot),
 	)
 
 	var serverConfigs []constant.ServerConfig

--- a/src/apiserver/pkg/utils/env.go
+++ b/src/apiserver/pkg/utils/env.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+)
+
+func GetStringFromEnv(key, defaultValue string) string {
+	if len(key) == 0 {
+		return defaultValue
+	}
+	value := os.Getenv(key)
+	if len(value) != 0 {
+		return value
+	}
+	return defaultValue
+}
+
+func GetIntFromEnv(key string, defaultValue int) int {
+	strValue := GetStringFromEnv(key, "")
+	if len(strValue) == 0 {
+		return defaultValue
+	}
+	if value, err := strconv.Atoi(strValue); err != nil {
+		return defaultValue
+	} else {
+		return value
+	}
+}
+
+func GetBoolFromEnv(key string, defaultValue bool) bool {
+	strValue := GetStringFromEnv(key, "")
+	if len(strValue) == 0 {
+		return defaultValue
+	}
+	if value, err := strconv.ParseBool(strValue); err != nil {
+		return defaultValue
+	} else {
+		return value
+	}
+}


### PR DESCRIPTION
1. Skip the __names__ item when enumerating all configs
2. Allow changing some Nacos options via environment variables
3. Use local Nacos config cache as a fallback by default