### PR TITLE
fix: Not to break the start-up process if higress-console ingress has been deleted already

### DIFF
--- a/all-in-one/scripts/start-apiserver.sh
+++ b/all-in-one/scripts/start-apiserver.sh
@@ -8,7 +8,7 @@ source $ROOT/base.sh
 set -e
 
 if [ "$ENABLE_CONSOLE_ROUTE" != "1" ]; then
-    sudo rm /opt/data/defaultConfig/ingresses/higress-console.yaml
+    sudo rm -f /opt/data/defaultConfig/ingresses/higress-console.yaml
 fi
 cp -rn /opt/data/defaultConfig/* /data
 


### PR DESCRIPTION
especially when running in docker compose.

fixes #70