### PR TITLE
fix: Adjust some status codes returned by API when delete operation fails

### DIFF
--- a/src/apiserver/pkg/registry/file_rest.go
+++ b/src/apiserver/pkg/registry/file_rest.go
@@ -473,11 +473,11 @@ func (f *fileREST) Delete(
 
 	oldObj, err := f.Get(ctx, name, nil)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(err)
+		return nil, false, err
 	}
 	if deleteValidation != nil {
 		if err := deleteValidation(ctx, oldObj); err != nil {
-			return nil, false, apierrors.NewInternalError(err)
+			return nil, false, apierrors.NewBadRequest(err.Error())
 		}
 	}
 

--- a/src/apiserver/pkg/registry/nacos_rest.go
+++ b/src/apiserver/pkg/registry/nacos_rest.go
@@ -374,11 +374,11 @@ func (n *nacosREST) Delete(
 
 	oldObj, err := n.Get(ctx, name, nil)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(err)
+		return nil, false, err
 	}
 	if deleteValidation != nil {
 		if err := deleteValidation(ctx, oldObj); err != nil {
-			return nil, false, apierrors.NewInternalError(err)
+			return nil, false, apierrors.NewBadRequest(err.Error())
 		}
 	}
 


### PR DESCRIPTION
Otherwise, when using Nacos as the storage and deleting an inexist resource, a 500 error will be returned.