### PR TITLE
fix: duplicate watcher id

### DIFF
--- a/src/apiserver/pkg/registry/file_rest.go
+++ b/src/apiserver/pkg/registry/file_rest.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/alibaba/higress/api-server/pkg/utils"
 	"github.com/fsnotify/fsnotify"
+	"github.com/google/uuid"
 )
 
 const fileChangeProcessInterval = 100 * time.Millisecond
@@ -78,7 +79,7 @@ func NewFileREST(
 		newListFunc:    newListFunc,
 		attrFunc:       attrFunc,
 		dirWatcher:     watcher,
-		fileWatchers:   make(map[int]*fileWatch, 10),
+		fileWatchers:   make(map[string]*fileWatch, 10),
 	}
 	err = f.startDirWatcher()
 	if err != nil {
@@ -101,7 +102,7 @@ type fileREST struct {
 	fileChangeMutex         sync.Mutex
 	fileChangeProcessTicker *time.Ticker
 	dirWatcher              *fsnotify.Watcher
-	fileWatchers            map[int]*fileWatch
+	fileWatchers            map[string]*fileWatch
 	fileWatchersMutex       sync.RWMutex
 
 	newFunc     func() runtime.Object
@@ -643,7 +644,7 @@ func (f *fileREST) visitDir(dirname string, extension string, newFunc func() run
 
 func (f *fileREST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
 	fw := &fileWatch{
-		id: len(f.fileWatchers),
+		id: uuid.New().String(),
 		f:  f,
 		ch: make(chan watch.Event, 10),
 	}
@@ -682,7 +683,7 @@ func (f *fileREST) predicateFunc(label labels.Selector, field fields.Selector) s
 
 type fileWatch struct {
 	f  *fileREST
-	id int
+	id string
 	ch chan watch.Event
 }
 

--- a/src/apiserver/pkg/registry/nacos_rest.go
+++ b/src/apiserver/pkg/registry/nacos_rest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/alibaba/higress/api-server/pkg/options"
 	"github.com/alibaba/higress/api-server/pkg/utils"
+	"github.com/google/uuid"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/config_client"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
@@ -83,7 +84,7 @@ func NewNacosREST(
 		newFunc:        newFunc,
 		newListFunc:    newListFunc,
 		attrFunc:       attrFunc,
-		watchers:       make(map[int]*nacosWatch, 10),
+		watchers:       make(map[string]*nacosWatch, 10),
 		encryptionKey:  dataEncryptionKey,
 	}
 	n.namesDataId = n.dataIdPrefix + dataIdSeparator + namesSuffix
@@ -104,7 +105,7 @@ type nacosREST struct {
 	listRefreshTicker  *time.Ticker
 	listConfigListened int32
 	watchersMutex      sync.RWMutex
-	watchers           map[int]*nacosWatch
+	watchers           map[string]*nacosWatch
 
 	newFunc     func() runtime.Object
 	newListFunc func() runtime.Object
@@ -446,7 +447,7 @@ func (n *nacosREST) Watch(ctx context.Context, options *metainternalversion.List
 	ns, _ := genericapirequest.NamespaceFrom(ctx)
 	predicate := n.buildListPredicate(options)
 	nw := &nacosWatch{
-		id:        len(n.watchers),
+		id:        uuid.New().String(),
 		f:         n,
 		ch:        make(chan watch.Event, 1024),
 		ns:        ns,
@@ -738,7 +739,7 @@ func calculateMd5(str string) string {
 
 type nacosWatch struct {
 	f         *nacosREST
-	id        int
+	id        string
 	ch        chan watch.Event
 	ns        string
 	predicate *storage.SelectionPredicate


### PR DESCRIPTION
Use watcher list length as watcher id could lead to duplicate watcher id, then the exist watcher will lost. This could happen when some watcher stopped and new watcher create.

1. create two watcher.
id: 0
id: 1

2. watcher with id 0 stopped，watcher list length is 1 now.

https://github.com/higress-group/higress-standalone/blob/1d580382d72e6a8bd01436aa6280cdc0a98ce762/src/apiserver/pkg/registry/file_rest.go#L689-L693

3. create new watcher, it's id is the watcher list length 1, which is duplicate with existing watcher.

https://github.com/higress-group/higress-standalone/blob/1d580382d72e6a8bd01436aa6280cdc0a98ce762/src/apiserver/pkg/registry/file_rest.go#L644-L649
