### PR TITLE
feat: Support modifying mesh config files in all-in-one images

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -64,14 +64,17 @@ COPY --from=grafana /usr/share/grafana /usr/share/grafana
 COPY --from=grafana /run.sh /usr/local/bin/grafana.sh
 
 # Install supervisord, logrotate, cron and initialize related folders
-RUN apt-get update --allow-unauthenticated && \
+RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+  apt-get update --allow-unauthenticated; \
   apt-get install --no-install-recommends -y --allow-unauthenticated \
-  supervisor logrotate cron \
-  && apt-get upgrade -y --allow-unauthenticated \
-  && apt-get clean \
-  && rm -rf /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old \
-  && mkdir -p /var/log/higress \
-  && mkdir /data
+    wget supervisor logrotate cron; \
+  apt-get upgrade -y --allow-unauthenticated; \
+  apt-get clean; \
+  rm -rf /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old; \
+  wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$arch -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq; \
+  mkdir -p /var/log/higress; \
+  mkdir /data;
+
 COPY ./supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Initialize configurations

--- a/all-in-one/config/configmaps/higress-config.yaml
+++ b/all-in-one/config/configmaps/higress-config.yaml
@@ -19,3 +19,29 @@ data:
     upstream:
       connectionBufferLimits: 10485760
       idleTimeout: 10
+  mesh: |-
+    accessLogEncoding: TEXT
+    accessLogFile: /dev/stdout
+    accessLogFormat: |
+      {"ai_log":"%FILTER_STATE(wasm.ai_log:PLAIN)%","authority":"%REQ(X-ENVOY-ORIGINAL-HOST?:AUTHORITY)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%","downstream_local_address":"%DOWNSTREAM_LOCAL_ADDRESS%","downstream_remote_address":"%DOWNSTREAM_REMOTE_ADDRESS%","duration":"%DURATION%","istio_policy_status":"%DYNAMIC_METADATA(istio.mixer:status)%","method":"%REQ(:METHOD)%","path":"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%","protocol":"%PROTOCOL%","request_id":"%REQ(X-REQUEST-ID)%","requested_server_name":"%REQUESTED_SERVER_NAME%","response_code":"%RESPONSE_CODE%","response_flags":"%RESPONSE_FLAGS%","route_name":"%ROUTE_NAME%","start_time":"%START_TIME%","trace_id":"%REQ(X-B3-TRACEID)%","upstream_cluster":"%UPSTREAM_CLUSTER%","upstream_host":"%UPSTREAM_HOST%","upstream_local_address":"%UPSTREAM_LOCAL_ADDRESS%","upstream_service_time":"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%","upstream_transport_failure_reason":"%UPSTREAM_TRANSPORT_FAILURE_REASON%","user_agent":"%REQ(USER-AGENT)%","x_forwarded_for":"%REQ(X-FORWARDED-FOR)%","response_code_details":"%RESPONSE_CODE_DETAILS%"}
+    configSources:
+    - address: xds://127.0.0.1:15051
+    - address: k8s://
+    defaultConfig:
+      disableAlpnH2: true
+      discoveryAddress: 127.0.0.1:15012
+      controlPlaneAuthPolicy: MUTUAL_TLS
+      proxyStatsMatcher:
+        inclusionRegexps:
+        - .*
+    dnsRefreshRate: 200s
+    enableAutoMtls: false
+    enablePrometheusMerge: true
+    ingressControllerMode: "OFF"
+    mseIngressGlobalConfig:
+      enableH3: false
+      enableProxyProtocol: false
+    protocolDetectionTimeout: 100ms
+    rootNamespace: higress-system
+    trustDomain: cluster.local
+  meshNetworks: 'networks: {}'

--- a/all-in-one/scripts/start-apiserver.sh
+++ b/all-in-one/scripts/start-apiserver.sh
@@ -22,4 +22,20 @@ if [ -n "$CONFIG_TEMPLATE" ]; then
     fi
 fi
 
+MESH_CONFIG_DIR='/etc/istio/config'
+mkdir -p $MESH_CONFIG_DIR
+HIGRESS_CONFIG_FILE="/data/configmaps/higress-config.yaml"
+MESH_CONFIG_FILES=$(yq '.data | keys | .[]' "$HIGRESS_CONFIG_FILE")
+if [ -z "$MESH_CONFIG_FILES" ]; then
+    echo "  Missing required files in higress-config ConfigMap."
+    exit -1
+fi
+IFS=$'\n'
+for MESH_CONFIG_FILE in $MESH_CONFIG_FILES; do
+    if [ -z "$MESH_CONFIG_FILE" -o "$MESH_CONFIG_FILE" == "higress" ]; then
+        continue
+    fi
+    yq ".data.$MESH_CONFIG_FILE" "$HIGRESS_CONFIG_FILE" > "$MESH_CONFIG_DIR/$MESH_CONFIG_FILE"
+done
+
 apiserver --bind-address 127.0.0.1 --secure-port 18443 --storage file --file-root-dir /data --cert-dir /tmp


### PR DESCRIPTION
During start-up, extract the content of mesh configs (`mesh` and `meshNetworks`) in `higress-config.yaml` file into `/etc/istio/config` dir. So user can modify them by changing the content of `higress-config.yaml`.