### PR TITLE
feat: Support customizing gateway concurrency

### DIFF
--- a/all-in-one/scripts/start-gateway.sh
+++ b/all-in-one/scripts/start-gateway.sh
@@ -27,6 +27,7 @@ else
 fi
 
 /usr/local/bin/higress-proxy-start.sh proxy router \
+    --concurrency=${GATEWAY_CONCURRENCY:-16} \
     --domain=higress-system.svc.cluster.local \
     --proxyLogLevel=${GATEWAY_LOG_LEVEL:-warning} \
     --proxyComponentLogLevel=${GATEWAY_COMPONENT_LOG_LEVEL:-misc:error} \

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -177,6 +177,8 @@ services:
     command:
       - proxy
       - router
+      - --concurrency
+      - "16"
       - --domain
       - higress-system.svc.cluster.local
       - --proxyLogLevel=warning


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Support customizing gateway concurrency.
2. Unify the default gateway concurrency to 16.

### Ⅱ. Does this pull request fix one issue?

fixes https://github.com/alibaba/higress/issues/2299

### Ⅲ. Usage

#### all-in-one

Add `-e GATEWAY_CONCURRENCY=xx` to the `docker run` command.

#### Docker Compose

Modify the `--concurrency` command line arg of gateway service in `docker-compose.yml`.



