### PR TITLE
fix: Improve the nacos legacy config checking logic

### DIFF
--- a/compose/scripts/init.sh
+++ b/compose/scripts/init.sh
@@ -14,7 +14,7 @@ now() {
 }
 
 base64UrlEncode() {
-  openssl enc -base64 -A | tr '+/' '-_' | tr -d '='; 
+  openssl enc -base64 -A | tr '+/' '-_' | tr -d '='
 }
 
 checkExitCode() {
@@ -35,10 +35,10 @@ initializeConfigStorage() {
     ;;
   file)
     initializeConfigDir
-      ;;
-    *)
-      printf "Unsupported storage type: %s\n" "$CONFIG_STORAGE"
-      ;;
+    ;;
+  *)
+    printf "Unsupported storage type: %s\n" "$CONFIG_STORAGE"
+    ;;
   esac
 }
 
@@ -46,8 +46,7 @@ initializeNacos() {
   nacosReady=false
 
   maxWaitTime=180
-  for (( i = 0; i < $maxWaitTime; i++ ))
-  do
+  for ((i = 0; i < $maxWaitTime; i++)); do
     statusCode=$(curl -s -o /dev/null -w "%{http_code}" "${NACOS_SERVER_URL}/")
     if [ "$statusCode" -eq "200" ]; then
       nacosReady=true
@@ -60,13 +59,13 @@ initializeNacos() {
 
   if [ "${nacosReady}" != "true" ]; then
     echo "Nacos server doesn't get ready within ${maxWaitTime} seconds. Initialization failed."
-    exit -1 
+    exit -1
   fi
 
   echo "Initializing Nacos server..."
 
   if [ -n "$NACOS_USERNAME" ] && [ -n "$NACOS_PASSWORD" ]; then
-    NACOS_ACCESS_TOKEN="$(curl -s "${NACOS_SERVER_URL}/v1/auth/login" -X POST --data-urlencode "username=${NACOS_USERNAME}" --data-urlencode "password=${NACOS_PASSWORD}" | jq -rM '.accessToken')";
+    NACOS_ACCESS_TOKEN="$(curl -s "${NACOS_SERVER_URL}/v1/auth/login" -X POST --data-urlencode "username=${NACOS_USERNAME}" --data-urlencode "password=${NACOS_PASSWORD}" | jq -rM '.accessToken')"
     if [ -z "$NACOS_ACCESS_TOKEN" ]; then
       echo "Unable to retrieve access token from Nacos. Possible causes are:"
       echo "  1. Incorrect username or password."
@@ -76,38 +75,38 @@ initializeNacos() {
 
   if grep -q "\"namespace\":\"${NACOS_NS}\"" <<<"$(curl -s "${NACOS_SERVER_URL}/v1/console/namespaces?accessToken=${NACOS_ACCESS_TOKEN}")"; then
     echo "  Namespace ${NACOS_NS} already exists in Nacos."
-
-    if [ "$NACOS_USE_RANDOM_DATA_ENC_KEY" != "Y" ]; then
-      echo "  Fixed data encryption key is used. Skip config overwriting check."
-    else
-      echo "  Checking existed configs in namespace ${NACOS_NS}..."
-      statusCode="$(curl -s -o /dev/null -w "%{http_code}" "${NACOS_SERVER_URL}/v2/cs/config?accessToken=${NACOS_ACCESS_TOKEN}&namespaceId=${NACOS_NS}&dataId=secrets.__names__&group=DEFAULT_GROUP")"
-      if [ $statusCode -eq 200 ]; then
-        echo "  ERROR: Higress configs are found in nacos namespace ${NACOS_NS}."
-        echo
-        echo "  Using a random data encyption key in a configured nacos namespace is incorrect, and will cause Higress unable to start."
-        echo "  You can:"
-        echo "  1. Remove all the configurations in nacos namespace ${NACOS_NS} and try again."
-        echo "  2. Install Higress to another nacos namespace."
-        echo "  3. Specify the same data encryption key generated/used in the previous installation."
-        exit -1
-      elif [ $statusCode -eq 404 ]; then
-        echo "  No Higress config is found in nacos namespace ${NACOS_NS}."
-      else
-        echo "  Checking existed configs in nacos namespace ${NACOS_NS} failed with $statusCode."
-        exit -1
-      fi
+  else
+    echo "  Creating namespace ${NACOS_NS}..."
+    statusCode="$(curl -s -o /dev/null -w "%{http_code}" "${NACOS_SERVER_URL}/v1/console/namespaces?accessToken=${NACOS_ACCESS_TOKEN}" --data-urlencode "customNamespaceId=${NACOS_NS}" --data-urlencode "namespaceName=${NACOS_NS}")"
+    if [ $statusCode -ne 200 ]; then
+      echo "  Creating namespace ${NACOS_NS} in nacos failed with $statusCode."
+      exit -1
     fi
-
-    return 0
   fi
 
-  echo "  Creating namespace ${NACOS_NS}..."
-  statusCode="$(curl -s -o /dev/null -w "%{http_code}" "${NACOS_SERVER_URL}/v1/console/namespaces?accessToken=${NACOS_ACCESS_TOKEN}" --data-urlencode "customNamespaceId=${NACOS_NS}" --data-urlencode "namespaceName=${NACOS_NS}")"
-  if [ $statusCode -ne 200 ]; then
-    echo "  Creating namespace ${NACOS_NS} in nacos failed with $statusCode."
-    exit -1
+  if [ "$NACOS_USE_RANDOM_DATA_ENC_KEY" != "Y" ]; then
+    echo "  Fixed data encryption key is used. Skip config overwriting check."
+  else
+    # Even the namespace is just created, there might be some dangling config items in it if the namespace itself was delete before without cleaning all the configs first.
+    echo "  Checking existed configs in namespace ${NACOS_NS}..."
+    statusCode="$(curl -s -o /dev/null -w "%{http_code}" "${NACOS_SERVER_URL}/v2/cs/config?accessToken=${NACOS_ACCESS_TOKEN}&namespaceId=${NACOS_NS}&dataId=secrets.__names__&group=DEFAULT_GROUP")"
+    if [ $statusCode -eq 200 ]; then
+      echo "  ERROR: Higress configs are found in nacos namespace ${NACOS_NS}."
+      echo
+      echo "  Using a random data encyption key in a configured nacos namespace is incorrect, and will cause Higress unable to start."
+      echo "  You can:"
+      echo "  1. Remove all the configurations in nacos namespace ${NACOS_NS} and try again."
+      echo "  2. Install Higress to another nacos namespace."
+      echo "  3. Specify the same data encryption key generated/used in the previous installation."
+      exit -1
+    elif [ $statusCode -eq 404 ]; then
+      echo "  No Higress config is found in nacos namespace ${NACOS_NS}."
+    else
+      echo "  Checking existed configs in nacos namespace ${NACOS_NS} failed with $statusCode."
+      exit -1
+    fi
   fi
+
   return 0
 }
 
@@ -132,12 +131,12 @@ initializeApiServer() {
   if [ ! -f nacos.key ]; then
     echo "  Generating data encryption key..."
     if [ -z "$NACOS_DATA_ENC_KEY" ]; then
-      cat /dev/urandom | tr -dc '[:graph:]' | head -c 32 > nacos.key
+      cat /dev/urandom | tr -dc '[:graph:]' | head -c 32 >nacos.key
     else
-      echo -n "$NACOS_DATA_ENC_KEY" > nacos.key
+      echo -n "$NACOS_DATA_ENC_KEY" >nacos.key
     fi
   else
-    echo "  Data encryption key already exists.";
+    echo "  Data encryption key already exists."
   fi
 }
 
@@ -151,7 +150,6 @@ initializeController() {
     chmod a+w ./log/nacos
   fi
 }
-
 
 initializeConfigStorage
 initializeApiServer


### PR DESCRIPTION
### Background

1. When using Nacos as the config storage, Higress API Server encrypts all the Secret data before writing to Nacos. A random encryption key will be generated during installation unless explictly provided.
2. Deleting a Nacos namespace won't clear any config items in it cascadingly.

### Current Situtation

User installs Higress to an empty Nacos instance, deletes the "higress-system" namespace from Nacos directly and tries to install Higress again.

During installation, since "higress-system" namespace doesn't exist in Nacos, `init.sh` won't check if there are any Secret resource existed in Nacos. Then the start-up process will get stuck because the API Server is unable to decrypt existed Secret data using the newly generated encryption key.

### Solution

No matter whether the target namespace exists or not in Nacos, `init.sh` perform the Secret resource check anyway.

### Extra Notes

Please be aware that some format issues are fixed in the PR as well.