### PR TITLE
fix: Unify resourceVersion check logic

### DIFF
--- a/src/apiserver/pkg/registry/file_rest.go
+++ b/src/apiserver/pkg/registry/file_rest.go
@@ -425,7 +425,8 @@ func (f *fileREST) Update(
 		}
 	}
 
-	if updatedAccessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+	currentResourceVersion := oldAccessor.GetResourceVersion()
+	if updatedAccessor.GetResourceVersion() != "" && currentResourceVersion != "" && updatedAccessor.GetResourceVersion() != currentResourceVersion {
 		requestInfo, ok := genericapirequest.RequestInfoFrom(ctx)
 		var groupResource = schema.GroupResource{}
 		if ok {
@@ -435,7 +436,6 @@ func (f *fileREST) Update(
 		return nil, false, apierrors.NewConflict(groupResource, name, nil)
 	}
 
-	currentResourceVersion := updatedAccessor.GetResourceVersion()
 	var newResourceVersion uint64
 	if currentResourceVersion == "" {
 		newResourceVersion = 1


### PR DESCRIPTION
When processing resource update requests, only check the `resourceVersion` field with the current `resourceVersion` value when the value in the request is not empty.

The Nacos storage implementation behaves like this now. This PR changes the behavior in the implementation of file storage.

https://github.com/higress-group/higress-standalone/blob/main/src/apiserver/pkg/registry/nacos_rest.go#L358
![image](https://github.com/user-attachments/assets/7da4be09-946d-49d8-a7cd-65127091d9f9)
