### PR TITLE
fix: Fix some envs when starting controller to avoid conflicts

### DIFF
--- a/all-in-one/supervisord/supervisord.conf
+++ b/all-in-one/supervisord/supervisord.conf
@@ -28,7 +28,7 @@ startsecs=1
 stdout_logfile=/var/log/higress/controller.log
 stdout_logfile_maxbytes=10MB
 redirect_stderr=true
-environment=CONTROLLER_KEEP_XDS_CONFIG_LABELS="false",CONTROLLER_KEEP_XDS_CONFIG_ANNOTATIONS="false",PILOT_ENABLE_GATEWAY_API="false",PILOT_ENABLE_ALPHA_GATEWAY_API="false",ENABLE_LEADER_ELECTION="false"
+environment=POD_NAME="higress-controller",POD_NAMESPACE="higress-system",CONTROLLER_KEEP_XDS_CONFIG_LABELS="false",CONTROLLER_KEEP_XDS_CONFIG_ANNOTATIONS="false",PILOT_ENABLE_GATEWAY_API="false",PILOT_ENABLE_ALPHA_GATEWAY_API="false",ENABLE_LEADER_ELECTION="false"
 
 [program:pilot]
 directory=/


### PR DESCRIPTION
Use fixed `POD_NAMESPACE` and `POD_NAME` envs when starting controller in `all-in-one` image, just in case that the image is deployed in a K8s cluster with these two envs injected by the K8s, causing controller only accepts the default `McpBridge` resource in that namespace.