### PR TITLE
fix: hardcode wasm plugin OCI URL versions to 2.0.0

### DIFF
--- a/all-in-one/scripts/config-template/ai-gateway.sh
+++ b/all-in-one/scripts/config-template/ai-gateway.sh
@@ -135,7 +135,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: UNSPECIFIED_PHASE
   priority: 100
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:$AI_PROXY_VERSION" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-proxy.internal.yaml"
+  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-proxy.internal.yaml"
 
 AI_STATISTICS_MATCH_RULES=""
 for i in "${GENERATED_INGRESSES[@]}"
@@ -181,7 +181,7 @@ spec:
   matchRules:$AI_STATISTICS_MATCH_RULES
   phase: UNSPECIFIED_PHASE
   priority: 900
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:$AI_STATISTICS_VERSION" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-statistics-1.0.0.yaml"
+  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-statistics-1.0.0.yaml"
 
   echo -e "\
 apiVersion: extensions.higress.io/v1alpha1
@@ -205,7 +205,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: AUTHN
   priority: 900
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-router:$MODEL_ROUTER_VERSION" >"$WASM_PLUGIN_CONFIG_FOLDER/model-router.internal.yaml"
+  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-router:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/model-router.internal.yaml"
 }
 
 function appendAiProxyConfigs() {

--- a/all-in-one/scripts/config-template/ai-proxy.sh
+++ b/all-in-one/scripts/config-template/ai-proxy.sh
@@ -125,7 +125,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: UNSPECIFIED_PHASE
   priority: \"100\"
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:$AI_PROXY_VERSION" > "$WASM_PLUGIN_CONFIG_FILE"
+  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0" > "$WASM_PLUGIN_CONFIG_FILE"
 }
 
 function initializeMcpBridge() {


### PR DESCRIPTION
将wasm插件 OCI URL中的版本号写死为2.0.0

## 修改内容

- `ai-gateway.sh`: 在OCI URL中将版本号写死为2.0.0（ai-proxy、ai-statistics、model-router）
- `ai-proxy.sh`: 在OCI URL中将版本号写死为2.0.0（ai-proxy）

## 影响

确保生成的wasm插件配置文件中OCI URL使用固定版本号2.0.0，例如：
`oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:2.0.0`

**注意：** 变量定义保持不变（如 `AI_PROXY_VERSION=${AI_PROXY_VERSION:-1.0.0}`），只在生成配置文件时的OCI URL中写死版本号。