### PR TITLE
feat: enable use_default_attributes for ai-statistics plugin

### DIFF
--- a/all-in-one/scripts/config-template/ai-gateway.sh
+++ b/all-in-one/scripts/config-template/ai-gateway.sh
@@ -137,29 +137,6 @@ spec:
   priority: 100
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-proxy.internal.yaml"
 
-AI_STATISTICS_MATCH_RULES=""
-for i in "${GENERATED_INGRESSES[@]}"
-do
-  AI_STATISTICS_MATCH_RULES="$AI_STATISTICS_MATCH_RULES
-  - config:
-      attributes:
-      - apply_to_log: true
-        key: question
-        value: messages.@reverse.0.content
-        value_source: request_body
-      - apply_to_log: true
-        key: answer
-        rule: append
-        value: choices.0.delta.content
-        value_source: response_streaming_body
-      - apply_to_log: true
-        key: answer
-        value: choices.0.message.content
-        value_source: response_body
-    configDisable: false
-    ingress:
-    - $i"
-done
   echo -e "\
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
@@ -176,9 +153,10 @@ metadata:
   namespace: higress-system
   resourceVersion: \"1\"
 spec:
-  defaultConfigDisable: true
+  defaultConfig:
+    use_default_attributes: true
+  defaultConfigDisable: false
   failStrategy: FAIL_OPEN
-  matchRules:$AI_STATISTICS_MATCH_RULES
   phase: UNSPECIFIED_PHASE
   priority: 900
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-statistics-1.0.0.yaml"


### PR DESCRIPTION
## Summary

Update ai-statistics WasmPlugin configuration in AI Gateway config template to use `use_default_attributes: true` by default, making the plugin apply globally with sensible defaults for LLM observability.

## Motivation

The previous configuration had two issues:
1. The plugin was disabled by default (`defaultConfigDisable: true`)
2. Required per-ingress matchRules with manual attribute configuration, which was verbose and error-prone

With the new `use_default_attributes` feature in ai-statistics plugin (higress#3427), we can simplify configuration significantly - the plugin now applies globally to all AI routes without needing matchRules.

## Changes

### Configuration Updates
- Changed `defaultConfigDisable` from `true` to `false` - plugin now enabled globally
- Added `defaultConfig` with `use_default_attributes: true` - uses default attributes automatically
- Removed `matchRules` completely - plugin applies to all routes globally
- Removed generated matchRules loop for all ingresses (25 lines total removed)

### Before
```yaml
spec:
  defaultConfigDisable: true  # Disabled by default
  matchRules:               # Per-ingress config required
    - config:
        attributes:
        - apply_to_log: true
          key: question
          value: messages.@reverse.0.content
          value_source: request_body
        # ... 12 more lines of attribute config
      configDisable: false
      ingress:
      - ai-route-openai.internal
    - configDisable: false
      ingress:
      - ai-route-moonshot.internal
    # ... more ingress entries
```

### After
```yaml
spec:
  defaultConfig:
    use_default_attributes: true  # Use sensible defaults
  defaultConfigDisable: false     # Enabled globally
  # No matchRules needed - applies to all routes automatically
```

### Benefits
- **Simpler**: 3 insertions, 25 deletions - much cleaner configuration
- **Better defaults**: Plugin enabled globally with sensible attributes for all AI routes
- **Easier to use**: No need to configure per-ingress matchRules or attributes
- **Still flexible**: Users can still override with custom configuration if needed

## Related Issues

- Depends on: alibaba/higress#3427 (use_default_attributes feature)
