### PR TITLE
feat: add /var/log/proxy mount and CLI parameters for non-interactive mode

### DIFF
--- a/all-in-one/get-ai-gateway.sh
+++ b/all-in-one/get-ai-gateway.sh
@@ -37,7 +37,14 @@ CONFIG_FILENAME="default.cfg"
 COMMAND_START="start"
 COMMAND_STOP="stop"
 COMMAND_DELETE="delete"
-KNOWN_COMMANDS=($COMMAND_START, $COMMAND_STOP, $COMMAND_DELETE)
+COMMAND_ROUTE="route"
+KNOWN_COMMANDS=($COMMAND_START, $COMMAND_STOP, $COMMAND_DELETE, $COMMAND_ROUTE)
+
+# Route subcommands
+ROUTE_ADD="add"
+ROUTE_LIST="list"
+ROUTE_REMOVE="remove"
+KNOWN_ROUTE_SUBCOMMANDS=($ROUTE_ADD, $ROUTE_LIST, $ROUTE_REMOVE)
 
 cd "$(dirname -- "$0")"
 ROOT="$(pwd -P)/higress"
@@ -260,6 +267,23 @@ parseArgs() {
       LLM_ENVS+=("GROK_API_KEY")
       shift 2
       ;;
+    # Route command options
+    --pattern)
+      ROUTE_PATTERN="$2"
+      shift 2
+      ;;
+    --model)
+      ROUTE_MODEL="$2"
+      shift 2
+      ;;
+    --trigger)
+      ROUTE_TRIGGER="$2"
+      shift 2
+      ;;
+    --rule-id)
+      ROUTE_RULE_ID="$2"
+      shift 2
+      ;;
     -* | --*)
       echo "Unknown option $1"
       exit 1
@@ -279,6 +303,24 @@ parseArgs() {
   if [[ ! ${KNOWN_COMMANDS[@]} =~ "$COMMAND" ]]; then
     echo "Unknown command: $COMMAND"
     exit 1
+  fi
+  
+  # Parse route subcommand
+  if [ "$COMMAND" == "$COMMAND_ROUTE" ]; then
+    if [ ${#POSITIONAL_ARGS[@]} -gt 0 ]; then
+      ROUTE_SUBCOMMAND="${POSITIONAL_ARGS[0]}"
+    else
+      ROUTE_SUBCOMMAND=""
+    fi
+    if [ -z "$ROUTE_SUBCOMMAND" ]; then
+      echo "Route subcommand required: add, list, remove"
+      exit 1
+    fi
+    if [[ ! ${KNOWN_ROUTE_SUBCOMMANDS[@]} =~ "$ROUTE_SUBCOMMAND" ]]; then
+      echo "Unknown route subcommand: $ROUTE_SUBCOMMAND"
+      echo "Available: add, list, remove"
+      exit 1
+    fi
   fi
 }
 
@@ -804,6 +846,12 @@ Commands:
   start                     Start the gateway (default)
   stop                      Stop the gateway
   delete                    Delete the gateway container
+  route                     Manage auto-routing rules (see below)
+
+Route Subcommands:
+  route add                 Add a new routing rule
+  route list                List all routing rules
+  route remove              Remove a routing rule by ID
 
 Options:
   -h, --help                Show this help message
@@ -822,6 +870,12 @@ Auto-Routing Options:
   --auto-routing            Enable auto-routing feature
   --auto-routing-default-model MODEL
                             Default model when no routing rule matches
+
+Route Options (for route add/remove):
+  --model MODEL             Target model for routing (required for add)
+  --trigger PHRASE          Trigger phrase(s), separated by | (e.g., "深入思考|deep thinking")
+  --pattern REGEX           Custom regex pattern (alternative to --trigger)
+  --rule-id ID              Rule ID to remove (required for remove)
 
 LLM Provider API Keys:
   --dashscope-key KEY       Aliyun Dashscope (Qwen) API key
@@ -861,6 +915,22 @@ Examples:
     --dashscope-key sk-xxx \\
     --auto-routing \\
     --auto-routing-default-model qwen-turbo
+
+  # Add a routing rule (route to claude for complex problems)
+  ./get-ai-gateway.sh route add \\
+    --model claude-opus-4.5 \\
+    --trigger "深入思考|deep thinking"
+
+  # Add a routing rule for coding
+  ./get-ai-gateway.sh route add \\
+    --model qwen-coder \\
+    --trigger "写代码|code:"
+
+  # List all routing rules
+  ./get-ai-gateway.sh route list
+
+  # Remove a routing rule
+  ./get-ai-gateway.sh route remove --rule-id 0
 '
 }
 
@@ -1074,6 +1144,300 @@ delete() {
   fi
 }
 
+# ============================================================================
+# Route Command Functions
+# ============================================================================
+
+MODEL_ROUTER_CONFIG_PATH="/data/wasmplugins/model-router.internal.yaml"
+
+# Generate a pattern from trigger phrase
+generatePattern() {
+  local trigger="$1"
+  # Split by | and create regex pattern
+  local patterns=""
+  IFS='|' read -ra TRIGGERS <<< "$trigger"
+  for t in "${TRIGGERS[@]}"; do
+    t=$(echo "$t" | xargs)  # trim whitespace
+    if [ -n "$patterns" ]; then
+      patterns="$patterns|$t"
+    else
+      patterns="$t"
+    fi
+  done
+  echo "(?i)^($patterns)"
+}
+
+# Check if container is running
+checkContainer() {
+  local running=$(docker ps --filter "name=^/${CONTAINER_NAME}$" --filter "status=running" --format "{{.Names}}")
+  if [ -z "$running" ]; then
+    echo "Error: Container '$CONTAINER_NAME' is not running."
+    echo "Start it first with: $0 start"
+    exit 1
+  fi
+}
+
+# Route add: Add a new routing rule
+routeAdd() {
+  checkContainer
+  
+  if [ -z "$ROUTE_MODEL" ]; then
+    echo "Error: --model is required"
+    echo "Usage: $0 route add --model <model-name> --trigger <trigger-phrase>"
+    echo "       $0 route add --model <model-name> --pattern <regex-pattern>"
+    exit 1
+  fi
+  
+  local pattern=""
+  if [ -n "$ROUTE_PATTERN" ]; then
+    pattern="$ROUTE_PATTERN"
+  elif [ -n "$ROUTE_TRIGGER" ]; then
+    pattern=$(generatePattern "$ROUTE_TRIGGER")
+  else
+    echo "Error: Either --trigger or --pattern is required"
+    echo "Usage: $0 route add --model <model-name> --trigger <trigger-phrase>"
+    echo "       $0 route add --model <model-name> --pattern <regex-pattern>"
+    exit 1
+  fi
+  
+  echo "Adding routing rule..."
+  echo "  Pattern: $pattern"
+  echo "  Model: $ROUTE_MODEL"
+  
+  # Copy config from container
+  local temp_file=$(mktemp)
+  docker cp "${CONTAINER_NAME}:${MODEL_ROUTER_CONFIG_PATH}" "$temp_file" 2>/dev/null
+  
+  if [ $? -ne 0 ]; then
+    echo "Error: Could not read model-router configuration from container"
+    rm -f "$temp_file"
+    exit 1
+  fi
+  
+  # Check if autoRouting section exists
+  if ! grep -q "autoRouting:" "$temp_file"; then
+    # Add autoRouting section
+    sedInPlace '/modelToHeader:/a\    autoRouting:\n      enable: true\n      defaultModel: qwen-turbo\n      rules: []' "$temp_file"
+  fi
+  
+  # Check if rules section exists under autoRouting
+  if ! grep -q "rules:" "$temp_file"; then
+    sedInPlace '/autoRouting:/a\      rules: []' "$temp_file"
+  fi
+  
+  # Add new rule - escape special characters for sed
+  local escaped_pattern=$(echo "$pattern" | sed 's/[&/\]/\\&/g')
+  local escaped_model=$(echo "$ROUTE_MODEL" | sed 's/[&/\]/\\&/g')
+  
+  # Use Python for reliable YAML editing if available, otherwise use sed
+  if command -v python3 &>/dev/null; then
+    python3 << EOF
+import yaml
+import sys
+
+with open('$temp_file', 'r') as f:
+    config = yaml.safe_load(f)
+
+if 'spec' not in config:
+    config['spec'] = {}
+if 'defaultConfig' not in config['spec']:
+    config['spec']['defaultConfig'] = {}
+if 'autoRouting' not in config['spec']['defaultConfig']:
+    config['spec']['defaultConfig']['autoRouting'] = {
+        'enable': True,
+        'defaultModel': 'qwen-turbo',
+        'rules': []
+    }
+if 'rules' not in config['spec']['defaultConfig']['autoRouting']:
+    config['spec']['defaultConfig']['autoRouting']['rules'] = []
+
+# Add new rule
+config['spec']['defaultConfig']['autoRouting']['rules'].append({
+    'pattern': '$pattern',
+    'model': '$ROUTE_MODEL'
+})
+
+with open('$temp_file', 'w') as f:
+    yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+EOF
+  else
+    # Fallback to sed (less reliable for YAML)
+    sedInPlace "/rules:/a\\        - pattern: $escaped_pattern\n          model: $escaped_model" "$temp_file"
+  fi
+  
+  # Copy back to container
+  docker cp "$temp_file" "${CONTAINER_NAME}:${MODEL_ROUTER_CONFIG_PATH}"
+  
+  if [ $? -ne 0 ]; then
+    echo "Error: Could not write model-router configuration to container"
+    rm -f "$temp_file"
+    exit 1
+  fi
+  
+  # Touch file to trigger reload
+  docker exec "$CONTAINER_NAME" touch "$MODEL_ROUTER_CONFIG_PATH"
+  
+  rm -f "$temp_file"
+  
+  echo
+  echo "✅ Routing rule added successfully!"
+  echo
+  echo "Configuration has been hot-reloaded (no restart needed)."
+  echo
+  if [ -n "$ROUTE_TRIGGER" ]; then
+    echo "Usage: Start your message with the trigger phrase to route to $ROUTE_MODEL"
+    echo "  Example: $ROUTE_TRIGGER How to solve this problem?"
+  else
+    echo "Pattern: $pattern"
+    echo "Model: $ROUTE_MODEL"
+  fi
+  echo
+  echo "Note: Make sure to use model='higress/auto' in your API request."
+}
+
+# Route list: List all routing rules
+routeList() {
+  checkContainer
+  
+  echo "Current routing rules:"
+  echo
+  
+  # Read config from container
+  local config=$(docker exec "$CONTAINER_NAME" cat "$MODEL_ROUTER_CONFIG_PATH" 2>/dev/null)
+  
+  if [ $? -ne 0 ]; then
+    echo "Error: Could not read model-router configuration from container"
+    exit 1
+  fi
+  
+  # Parse and display rules using Python if available
+  if command -v python3 &>/dev/null; then
+    echo "$config" | python3 << 'EOF'
+import yaml
+import sys
+
+config = yaml.safe_load(sys.stdin.read())
+auto_routing = config.get('spec', {}).get('defaultConfig', {}).get('autoRouting', {})
+
+if not auto_routing.get('enable', False):
+    print("Auto-routing is DISABLED")
+    print()
+    print("Enable it with: ./get-ai-gateway.sh start --auto-routing")
+    sys.exit(0)
+
+default_model = auto_routing.get('defaultModel', 'not set')
+print(f"Default model: {default_model}")
+print()
+
+rules = auto_routing.get('rules', [])
+if not rules:
+    print("No routing rules configured.")
+    print()
+    print("Add a rule with:")
+    print("  ./get-ai-gateway.sh route add --model <model> --trigger '<trigger-phrase>'")
+else:
+    print(f"{'ID':<4} {'Pattern':<40} {'Model':<20}")
+    print("-" * 70)
+    for i, rule in enumerate(rules):
+        pattern = rule.get('pattern', 'N/A')[:38]
+        model = rule.get('model', 'N/A')
+        print(f"{i:<4} {pattern:<40} {model:<20}")
+EOF
+  else
+    # Fallback: just show raw config section
+    echo "$config" | grep -A 100 "autoRouting:" | head -50
+  fi
+}
+
+# Route remove: Remove a routing rule by ID
+routeRemove() {
+  checkContainer
+  
+  if [ -z "$ROUTE_RULE_ID" ]; then
+    echo "Error: --rule-id is required"
+    echo "Usage: $0 route remove --rule-id <id>"
+    echo
+    echo "Use '$0 route list' to see rule IDs"
+    exit 1
+  fi
+  
+  echo "Removing routing rule ID: $ROUTE_RULE_ID"
+  
+  # Copy config from container
+  local temp_file=$(mktemp)
+  docker cp "${CONTAINER_NAME}:${MODEL_ROUTER_CONFIG_PATH}" "$temp_file" 2>/dev/null
+  
+  if [ $? -ne 0 ]; then
+    echo "Error: Could not read model-router configuration from container"
+    rm -f "$temp_file"
+    exit 1
+  fi
+  
+  # Remove rule using Python
+  if command -v python3 &>/dev/null; then
+    python3 << EOF
+import yaml
+import sys
+
+with open('$temp_file', 'r') as f:
+    config = yaml.safe_load(f)
+
+rules = config.get('spec', {}).get('defaultConfig', {}).get('autoRouting', {}).get('rules', [])
+
+rule_id = int('$ROUTE_RULE_ID')
+if rule_id < 0 or rule_id >= len(rules):
+    print(f"Error: Rule ID {rule_id} not found. Use 'route list' to see available rules.")
+    sys.exit(1)
+
+removed = rules.pop(rule_id)
+print(f"Removed rule: pattern='{removed.get('pattern')}', model='{removed.get('model')}'")
+
+with open('$temp_file', 'w') as f:
+    yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+EOF
+    
+    if [ $? -ne 0 ]; then
+      rm -f "$temp_file"
+      exit 1
+    fi
+  else
+    echo "Error: Python3 is required for removing rules"
+    rm -f "$temp_file"
+    exit 1
+  fi
+  
+  # Copy back to container
+  docker cp "$temp_file" "${CONTAINER_NAME}:${MODEL_ROUTER_CONFIG_PATH}"
+  
+  # Touch file to trigger reload
+  docker exec "$CONTAINER_NAME" touch "$MODEL_ROUTER_CONFIG_PATH"
+  
+  rm -f "$temp_file"
+  
+  echo
+  echo "✅ Routing rule removed successfully!"
+  echo "Configuration has been hot-reloaded."
+}
+
+# Route command dispatcher
+route() {
+  case "$ROUTE_SUBCOMMAND" in
+  "$ROUTE_ADD")
+    routeAdd
+    ;;
+  "$ROUTE_LIST")
+    routeList
+    ;;
+  "$ROUTE_REMOVE")
+    routeRemove
+    ;;
+  esac
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
 initArch
 initOS
 parseArgs "$@"
@@ -1091,5 +1455,8 @@ case $COMMAND in
   ;;
 "$COMMAND_DELETE")
   delete
+  ;;
+"$COMMAND_ROUTE")
+  route
   ;;
 esac


### PR DESCRIPTION

1. Mount /var/log/proxy from container to $DATA_FOLDER/logs on host
   - Enables access to gateway access logs for external monitoring
   - Useful for token tracking and session analysis

2. Add comprehensive CLI parameters for non-interactive configuration:
   - --non-interactive/--batch: Run in batch mode without prompts
   - Port configuration: --http-port, --https-port, --console-port
   - Container options: --container-name, --image-repo, --image-tag
   - Data folder: --data-folder
   - Auto-routing: --auto-routing, --auto-routing-default-model
   - LLM Provider API Keys for 20+ providers

Examples:
  # Non-interactive with Dashscope
  ./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx

  # With auto-routing
  ./get-ai-gateway.sh start --non-interactive \
    --dashscope-key sk-xxx --auto-routing --auto-routing-default-model qwen-turbo