### PR TITLE
feat: add config subcommand to manage API keys

### DIFF
--- a/all-in-one/get-ai-gateway.sh
+++ b/all-in-one/get-ai-gateway.sh
@@ -38,13 +38,20 @@ COMMAND_START="start"
 COMMAND_STOP="stop"
 COMMAND_DELETE="delete"
 COMMAND_ROUTE="route"
-KNOWN_COMMANDS=($COMMAND_START, $COMMAND_STOP, $COMMAND_DELETE, $COMMAND_ROUTE)
+COMMAND_CONFIG="config"
+KNOWN_COMMANDS=($COMMAND_START, $COMMAND_STOP, $COMMAND_DELETE, $COMMAND_ROUTE, $COMMAND_CONFIG)
 
 # Route subcommands
 ROUTE_ADD="add"
 ROUTE_LIST="list"
 ROUTE_REMOVE="remove"
 KNOWN_ROUTE_SUBCOMMANDS=($ROUTE_ADD, $ROUTE_LIST, $ROUTE_REMOVE)
+
+# Config subcommands
+CONFIG_ADD="add"
+CONFIG_LIST="list"
+CONFIG_REMOVE="remove"
+KNOWN_CONFIG_SUBCOMMANDS=($CONFIG_ADD, $CONFIG_LIST, $CONFIG_REMOVE)
 
 cd "$(dirname -- "$0")"
 ROOT="$(pwd -P)/higress"
@@ -284,6 +291,15 @@ parseArgs() {
       ROUTE_RULE_ID="$2"
       shift 2
       ;;
+    # Config command options
+    --provider)
+      CONFIG_PROVIDER="$2"
+      shift 2
+      ;;
+    --key)
+      CONFIG_KEY="$2"
+      shift 2
+      ;;
     -* | --*)
       echo "Unknown option $1"
       exit 1
@@ -318,6 +334,24 @@ parseArgs() {
     fi
     if [[ ! ${KNOWN_ROUTE_SUBCOMMANDS[@]} =~ "$ROUTE_SUBCOMMAND" ]]; then
       echo "Unknown route subcommand: $ROUTE_SUBCOMMAND"
+      echo "Available: add, list, remove"
+      exit 1
+    fi
+  fi
+  
+  # Parse config subcommand
+  if [ "$COMMAND" == "$COMMAND_CONFIG" ]; then
+    if [ ${#POSITIONAL_ARGS[@]} -gt 0 ]; then
+      CONFIG_SUBCOMMAND="${POSITIONAL_ARGS[0]}"
+    else
+      CONFIG_SUBCOMMAND=""
+    fi
+    if [ -z "$CONFIG_SUBCOMMAND" ]; then
+      echo "Config subcommand required: add, list, remove"
+      exit 1
+    fi
+    if [[ ! ${KNOWN_CONFIG_SUBCOMMANDS[@]} =~ "$CONFIG_SUBCOMMAND" ]]; then
+      echo "Unknown config subcommand: $CONFIG_SUBCOMMAND"
       echo "Available: add, list, remove"
       exit 1
     fi
@@ -847,11 +881,17 @@ Commands:
   stop                      Stop the gateway
   delete                    Delete the gateway container
   route                     Manage auto-routing rules (see below)
+  config                    Manage API key configuration (see below)
 
 Route Subcommands:
   route add                 Add a new routing rule
   route list                List all routing rules
   route remove              Remove a routing rule by ID
+
+Config Subcommands:
+  config add                Add or update an API key
+  config list               List all configured API keys
+  config remove             Remove an API key
 
 Options:
   -h, --help                Show this help message
@@ -876,6 +916,10 @@ Route Options (for route add/remove):
   --trigger PHRASE          Trigger phrase(s), separated by | (e.g., "深入思考|deep thinking")
   --pattern REGEX           Custom regex pattern (alternative to --trigger)
   --rule-id ID              Rule ID to remove (required for remove)
+
+Config Options (for config add/remove):
+  --provider PROVIDER       Provider name (dashscope, deepseek, moonshot, etc.)
+  --key KEY                 API key to set (required for add)
 
 LLM Provider API Keys:
   --dashscope-key KEY       Aliyun Dashscope (Qwen) API key
@@ -931,6 +975,15 @@ Examples:
 
   # Remove a routing rule
   ./get-ai-gateway.sh route remove --rule-id 0
+
+  # List all configured API keys
+  ./get-ai-gateway.sh config list
+
+  # Add or update an API key
+  ./get-ai-gateway.sh config add --provider deepseek --key sk-xxx
+
+  # Remove an API key
+  ./get-ai-gateway.sh config remove --provider deepseek
 '
 }
 
@@ -1142,6 +1195,279 @@ delete() {
   if [ $? -eq 0 ]; then
     echo "Thanks for using Higress AI Gateway."
   fi
+}
+
+# ============================================================================
+# Config Command Functions
+# ============================================================================
+
+# Get provider name from environment variable name
+getProviderName() {
+  local env_var="$1"
+  case "$env_var" in
+    DASHSCOPE_API_KEY) echo "Aliyun Dashscope (Qwen)" ;;
+    DEEPSEEK_API_KEY) echo "DeepSeek" ;;
+    MOONSHOT_API_KEY) echo "Moonshot (Kimi)" ;;
+    ZHIPUAI_API_KEY) echo "Zhipu AI" ;;
+    OPENAI_API_KEY) echo "OpenAI" ;;
+    OPENROUTER_API_KEY) echo "OpenRouter" ;;
+    CLAUDE_API_KEY) echo "Claude" ;;
+    GEMINI_API_KEY) echo "Google Gemini" ;;
+    GROQ_API_KEY) echo "Groq" ;;
+    DOUBAO_API_KEY) echo "Doubao" ;;
+    BAICHUAN_API_KEY) echo "Baichuan AI" ;;
+    YI_API_KEY) echo "01.AI (Yi)" ;;
+    STEPFUN_API_KEY) echo "Stepfun" ;;
+    MINIMAX_API_KEY) echo "Minimax" ;;
+    COHERE_API_KEY) echo "Cohere" ;;
+    MISTRAL_API_KEY) echo "Mistral AI" ;;
+    GITHUB_API_KEY) echo "Github Models" ;;
+    FIREWORKS_API_KEY) echo "Fireworks AI" ;;
+    TOGETHERAI_API_KEY) echo "Together AI" ;;
+    GROK_API_KEY) echo "Grok" ;;
+    *) echo "Unknown ($env_var)" ;;
+  esac
+}
+
+# Get environment variable name from provider shorthand
+getEnvVarName() {
+  local provider="$1"
+  case "$provider" in
+    dashscope|qwen) echo "DASHSCOPE_API_KEY" ;;
+    deepseek) echo "DEEPSEEK_API_KEY" ;;
+    moonshot|kimi) echo "MOONSHOT_API_KEY" ;;
+    zhipuai|zhipu) echo "ZHIPUAI_API_KEY" ;;
+    openai) echo "OPENAI_API_KEY" ;;
+    openrouter) echo "OPENROUTER_API_KEY" ;;
+    claude) echo "CLAUDE_API_KEY" ;;
+    gemini) echo "GEMINI_API_KEY" ;;
+    groq) echo "GROQ_API_KEY" ;;
+    doubao) echo "DOUBAO_API_KEY" ;;
+    baichuan) echo "BAICHUAN_API_KEY" ;;
+    yi) echo "YI_API_KEY" ;;
+    stepfun) echo "STEPFUN_API_KEY" ;;
+    minimax) echo "MINIMAX_API_KEY" ;;
+    cohere) echo "COHERE_API_KEY" ;;
+    mistral) echo "MISTRAL_API_KEY" ;;
+    github) echo "GITHUB_API_KEY" ;;
+    fireworks) echo "FIREWORKS_API_KEY" ;;
+    togetherai|together) echo "TOGETHERAI_API_KEY" ;;
+    grok) echo "GROK_API_KEY" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Mask API key for display
+maskApiKey() {
+  local key="$1"
+  if [ -z "$key" ]; then
+    echo "<not set>"
+    return
+  fi
+  local len=${#key}
+  if [ $len -le 8 ]; then
+    echo "${key:0:2}***"
+  else
+    echo "${key:0:4}***${key: -4}"
+  fi
+}
+
+# Config list: List all configured API keys
+configList() {
+  local config_file="$ROOT/$CONFIG_FILENAME"
+  
+  if [ ! -f "$config_file" ]; then
+    echo "Error: Configuration file not found: $config_file"
+    echo "Please start the gateway first with: $0 start"
+    exit 1
+  fi
+  
+  echo "Current LLM Provider API Keys:"
+  echo
+  
+  # List of known API key environment variables
+  local api_keys=(
+    "DASHSCOPE_API_KEY"
+    "DEEPSEEK_API_KEY"
+    "MOONSHOT_API_KEY"
+    "ZHIPUAI_API_KEY"
+    "OPENAI_API_KEY"
+    "OPENROUTER_API_KEY"
+    "CLAUDE_API_KEY"
+    "GEMINI_API_KEY"
+    "GROQ_API_KEY"
+    "DOUBAO_API_KEY"
+    "BAICHUAN_API_KEY"
+    "YI_API_KEY"
+    "STEPFUN_API_KEY"
+    "MINIMAX_API_KEY"
+    "COHERE_API_KEY"
+    "MISTRAL_API_KEY"
+    "GITHUB_API_KEY"
+    "FIREWORKS_API_KEY"
+    "TOGETHERAI_API_KEY"
+    "GROK_API_KEY"
+  )
+  
+  local found=0
+  for env_var in "${api_keys[@]}"; do
+    local value=$(grep "^${env_var}=" "$config_file" | cut -d'=' -f2-)
+    if [ -n "$value" ]; then
+      local provider_name=$(getProviderName "$env_var")
+      local masked=$(maskApiKey "$value")
+      printf "  %-25s %s\n" "$provider_name:" "$masked"
+      found=1
+    fi
+  done
+  
+  if [ $found -eq 0 ]; then
+    echo "  No API keys configured."
+    echo
+    echo "Add an API key with:"
+    echo "  $0 config add --provider <provider> --key <api-key>"
+  else
+    echo
+    echo "Update an API key with:"
+    echo "  $0 config add --provider <provider> --key <new-api-key>"
+    echo
+    echo "Remove an API key with:"
+    echo "  $0 config remove --provider <provider>"
+  fi
+}
+
+# Config add: Add or update an API key
+configAdd() {
+  if [ -z "$CONFIG_PROVIDER" ]; then
+    echo "Error: --provider is required"
+    echo
+    echo "Supported providers:"
+    echo "  dashscope, deepseek, moonshot, zhipuai, openai, openrouter,"
+    echo "  claude, gemini, groq, doubao, baichuan, yi, stepfun, minimax,"
+    echo "  cohere, mistral, github, fireworks, togetherai, grok"
+    echo
+    echo "Usage: $0 config add --provider <provider> --key <api-key>"
+    exit 1
+  fi
+  
+  if [ -z "$CONFIG_KEY" ]; then
+    echo "Error: --key is required"
+    echo "Usage: $0 config add --provider <provider> --key <api-key>"
+    exit 1
+  fi
+  
+  local config_file="$ROOT/$CONFIG_FILENAME"
+  
+  if [ ! -f "$config_file" ]; then
+    echo "Error: Configuration file not found: $config_file"
+    echo "Please start the gateway first with: $0 start"
+    exit 1
+  fi
+  
+  local env_var=$(getEnvVarName "$CONFIG_PROVIDER")
+  if [ -z "$env_var" ]; then
+    echo "Error: Unknown provider: $CONFIG_PROVIDER"
+    echo
+    echo "Supported providers:"
+    echo "  dashscope, deepseek, moonshot, zhipuai, openai, openrouter,"
+    echo "  claude, gemini, groq, doubao, baichuan, yi, stepfun, minimax,"
+    echo "  cohere, mistral, github, fireworks, togetherai, grok"
+    exit 1
+  fi
+  
+  local provider_name=$(getProviderName "$env_var")
+  
+  # Check if the key already exists
+  if grep -q "^${env_var}=" "$config_file"; then
+    echo "Updating existing API key for $provider_name..."
+    sedInPlace "/^${env_var}=/c\\${env_var}=${CONFIG_KEY}" "$config_file"
+  else
+    echo "Adding new API key for $provider_name..."
+    echo "${env_var}=${CONFIG_KEY}" >> "$config_file"
+  fi
+  
+  if [ $? -eq 0 ]; then
+    echo
+    echo "✅ API key updated successfully!"
+    echo
+    echo "Provider: $provider_name"
+    echo "Key: $(maskApiKey "$CONFIG_KEY")"
+    echo
+    echo "Restart the gateway to apply changes:"
+    echo "  $0 stop && $0 start"
+  else
+    echo "Error: Failed to update configuration file"
+    exit 1
+  fi
+}
+
+# Config remove: Remove an API key
+configRemove() {
+  if [ -z "$CONFIG_PROVIDER" ]; then
+    echo "Error: --provider is required"
+    echo "Usage: $0 config remove --provider <provider>"
+    exit 1
+  fi
+  
+  local config_file="$ROOT/$CONFIG_FILENAME"
+  
+  if [ ! -f "$config_file" ]; then
+    echo "Error: Configuration file not found: $config_file"
+    echo "Please start the gateway first with: $0 start"
+    exit 1
+  fi
+  
+  local env_var=$(getEnvVarName "$CONFIG_PROVIDER")
+  if [ -z "$env_var" ]; then
+    echo "Error: Unknown provider: $CONFIG_PROVIDER"
+    echo
+    echo "Supported providers:"
+    echo "  dashscope, deepseek, moonshot, zhipuai, openai, openrouter,"
+    echo "  claude, gemini, groq, doubao, baichuan, yi, stepfun, minimax,"
+    echo "  cohere, mistral, github, fireworks, togetherai, grok"
+    exit 1
+  fi
+  
+  local provider_name=$(getProviderName "$env_var")
+  
+  # Check if the key exists
+  if ! grep -q "^${env_var}=" "$config_file"; then
+    echo "Error: No API key configured for $provider_name"
+    echo
+    echo "Current configuration:"
+    echo "  $0 config list"
+    exit 1
+  fi
+  
+  # Remove the key
+  sedInPlace "/^${env_var}=/d" "$config_file"
+  
+  if [ $? -eq 0 ]; then
+    echo
+    echo "✅ API key removed successfully!"
+    echo
+    echo "Provider: $provider_name"
+    echo
+    echo "Restart the gateway to apply changes:"
+    echo "  $0 stop && $0 start"
+  else
+    echo "Error: Failed to update configuration file"
+    exit 1
+  fi
+}
+
+# Config command dispatcher
+config() {
+  case "$CONFIG_SUBCOMMAND" in
+  "$CONFIG_ADD")
+    configAdd
+    ;;
+  "$CONFIG_LIST")
+    configList
+    ;;
+  "$CONFIG_REMOVE")
+    configRemove
+    ;;
+  esac
 }
 
 # ============================================================================
@@ -1458,5 +1784,8 @@ case $COMMAND in
   ;;
 "$COMMAND_ROUTE")
   route
+  ;;
+"$COMMAND_CONFIG")
+  config
   ;;
 esac


### PR DESCRIPTION
## Description

This PR adds a new `config` subcommand to the `get-ai-gateway.sh` script for managing LLM provider API keys.

## Changes

### New Commands
- `config add --provider <provider> --key <api-key>` - Add or update an API key
- `config list` - List all configured API keys (with masking for security)
- `config remove --provider <provider>` - Remove an API key

### Features
- Support for all LLM providers (dashscope, deepseek, openai, claude, gemini, etc.)
- User-friendly provider name mapping (e.g., `qwen` → `DASHSCOPE_API_KEY`)
- API key masking in list output (e.g., `sk-ab***cd12`)
- Clear error messages and usage instructions
- Updated help documentation with examples

### Examples

```bash
# List all configured API keys
./get-ai-gateway.sh config list

# Add or update an API key
./get-ai-gateway.sh config add --provider deepseek --key sk-xxx

# Remove an API key
./get-ai-gateway.sh config remove --provider deepseek
```

## Benefits
- Easier management of API keys without manually editing config files
- Better security with masked display of sensitive keys
- Improved user experience for updating credentials

## Testing
- [x] Syntax check passed (`bash -n`)
- [x] Command parsing works correctly
- [x] Help documentation updated

## Related Issue
N/A