### PR TITLE
fix: use shared fsnotify watcher to avoid 'too many open files' error

### DIFF
--- a/src/apiserver/pkg/apiserver/apiserver.go
+++ b/src/apiserver/pkg/apiserver/apiserver.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"fmt"
 
+	"github.com/fsnotify/fsnotify"
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -169,6 +170,15 @@ func (c completedConfig) New() (*HigressServer, error) {
 		}
 	}
 
+	// Create shared watcher for file storage mode to avoid "too many open files"
+	var sharedWatcher *fsnotify.Watcher
+	if storageMode == options.Storage_File {
+		sharedWatcher, err = fsnotify.NewWatcher()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create shared file watcher: %v", err)
+		}
+	}
+
 	storageCreateFunc := func(
 		groupResource schema.GroupResource,
 		runtimeCodec runtime.Codec,
@@ -185,7 +195,7 @@ func (c completedConfig) New() (*HigressServer, error) {
 		switch storageMode {
 		case options.Storage_File:
 			runtimeCodec = codec.NewFlatAwareCodec(groupResource, runtimeCodec)
-			return registry.NewFileREST(groupResource, runtimeCodec, storageOptions.FileOptions.RootDir, extension, isNamespaced, singularName, newFunc, newListFunc, attrFunc)
+			return registry.NewFileREST(groupResource, runtimeCodec, storageOptions.FileOptions.RootDir, extension, isNamespaced, singularName, newFunc, newListFunc, attrFunc, sharedWatcher)
 		case options.Storage_Nacos:
 			var encryptionKey []byte = nil
 			if sensitive {


### PR DESCRIPTION
## Problem

The API server crashes with panic: `too many open files` when creating REST storage for resources.

Root cause: Each resource type (ConfigMap, Secret, Ingress, etc.) creates its own `fsnotify.Watcher` instance in `NewFileREST()`, which consumes file descriptors. When the number of resource types exceeds the system limit, the application crashes.

## Solution

Use a **shared `fsnotify.Watcher`** across all fileREST instances:

1. Create one global watcher in `completedConfig.New()` for File storage mode
2. Pass the shared watcher to all `NewFileREST()` calls
3. Update `Destroy()` to not close the watcher (managed by server lifecycle)

## Changes

- `src/apiserver/pkg/apiserver/apiserver.go`: Create and pass shared watcher
- `src/apiserver/pkg/registry/file_rest.go`: Accept shared watcher parameter, remove per-instance watcher creation

## Testing

Before: Application crashes with "too many open files" when registering multiple resources
After: All resources share one watcher, file descriptor usage reduced significantly

Fixes the panic reported in production environments.