### PR TITLE
fix: declare err variable inline for startDirWatcher call

### DIFF
--- a/src/apiserver/pkg/registry/file_rest.go
+++ b/src/apiserver/pkg/registry/file_rest.go
@@ -78,8 +78,7 @@ func NewFileREST(
 		dirWatcher:     sharedWatcher,
 		fileWatchers:   make(map[string]*fileWatch, 10),
 	}
-	err = f.startDirWatcher()
-	if err != nil {
+	if err := f.startDirWatcher(); err != nil {
 		return nil, err
 	}
 	return f, nil


### PR DESCRIPTION
## Problem

After PR #236 was merged, compilation fails with:

```
pkg/registry/file_rest.go:81:2: undefined: err
pkg/registry/file_rest.go:82:5: undefined: err
pkg/registry/file_rest.go:83:15: undefined: err
```

## Root Cause

PR #236 removed the `watcher, err := fsnotify.NewWatcher()` lines but the code still references the `err` variable on the next lines.

## Solution

Change:
```go
err = f.startDirWatcher()
if err != nil {
    return nil, err
}
```

To:
```go
if err := f.startDirWatcher(); err != nil {
    return nil, err
}
```

This declares `err` inline, fixing the undefined variable error.

## Testing

Compilation now succeeds.