### PR TITLE
fix: revert to per-resource watcher + increase FD limit at startup

### DIFF
--- a/src/apiserver/pkg/apiserver/apiserver.go
+++ b/src/apiserver/pkg/apiserver/apiserver.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"fmt"
 
-	"github.com/fsnotify/fsnotify"
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -170,15 +169,6 @@ func (c completedConfig) New() (*HigressServer, error) {
 		}
 	}
 
-	// Create shared watcher for file storage mode to avoid "too many open files"
-	var sharedWatcher *fsnotify.Watcher
-	if storageMode == options.Storage_File {
-		sharedWatcher, err = fsnotify.NewWatcher()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create shared file watcher: %v", err)
-		}
-	}
-
 	storageCreateFunc := func(
 		groupResource schema.GroupResource,
 		runtimeCodec runtime.Codec,
@@ -195,7 +185,7 @@ func (c completedConfig) New() (*HigressServer, error) {
 		switch storageMode {
 		case options.Storage_File:
 			runtimeCodec = codec.NewFlatAwareCodec(groupResource, runtimeCodec)
-			return registry.NewFileREST(groupResource, runtimeCodec, storageOptions.FileOptions.RootDir, extension, isNamespaced, singularName, newFunc, newListFunc, attrFunc, sharedWatcher)
+			return registry.NewFileREST(groupResource, runtimeCodec, storageOptions.FileOptions.RootDir, extension, isNamespaced, singularName, newFunc, newListFunc, attrFunc)
 		case options.Storage_Nacos:
 			var encryptionKey []byte = nil
 			if sensitive {


### PR DESCRIPTION
## Problem

PR #236's shared watcher approach causes runtime failure:
```
command failed err="failed to create shared file watcher: too many open files"
```

## Root Cause Analysis

The shared watcher design has **fundamental architectural flaws**:

1. **Event channel conflict**: Each fileREST instance starts a goroutine reading from the **same** `watcher.Events` channel
   - Multiple goroutines competing for events
   - Events are distributed randomly (only one goroutine receives each event)
   - Resources miss their own file change events

2. **Directory watch conflicts**: Each resource calls `dirWatcher.Add(objRootPath)` on different subdirectories
   - Potentially causes fsnotify internal issues

3. **Still hits FD limit**: Even with shared watcher, other initialization steps may consume FDs before watcher creation

## Solution

**Revert to per-resource watcher** (simpler & correct) **+ increase system FD limit early**:

### Changes

1. **main.go**: Add `init()` to increase FD limit to 65535 before any initialization
   - Runs before any watcher/file operations
   - Logs current and updated limits for debugging
   - Gracefully handles permission errors

2. **file_rest.go**: Restore per-resource watcher creation
   - Each resource gets isolated event stream (correct behavior)
   - Add resource name to error messages for debugging
   - Properly close watcher in `Destroy()`

3. **apiserver.go**: Remove shared watcher logic
   - Simplify code
   - Remove fsnotify import

## Why This Works

- **FD limit increased early**: Before any file operations
- **Proper event isolation**: Each resource processes only its own events
- **Simpler architecture**: Less complexity = fewer bugs
- **Typical deployments have <50 resources**: Even at 1 watcher/resource, well under 65535 limit

## Testing

- Compiles successfully
- FD limit increased at startup (logged)
- Each resource independently watches its directory
- No event distribution conflicts

## Alternative Considered

A truly shared watcher would require:
- Single goroutine reading events
- Event dispatcher routing to correct resource based on file path
- Complex synchronization

This adds significant complexity for minimal benefit given FD limits are easily increased.

---

Supersedes #236 and #237