### PR TITLE
feat: auto-select plugin registry based on timezone

### DIFF
--- a/all-in-one/scripts/config-template/ai-gateway.sh
+++ b/all-in-one/scripts/config-template/ai-gateway.sh
@@ -385,7 +385,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: UNSPECIFIED_PHASE
   priority: 100
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-proxy.internal.yaml"
+  url: oci://${PLUGIN_REGISTRY:-higress-registry.cn-hangzhou.cr.aliyuncs.com}/plugins/ai-proxy:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-proxy.internal.yaml"
 
   echo -e "\
 apiVersion: extensions.higress.io/v1alpha1
@@ -409,7 +409,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: UNSPECIFIED_PHASE
   priority: 900
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-statistics-1.0.0.yaml"
+  url: oci://${PLUGIN_REGISTRY:-higress-registry.cn-hangzhou.cr.aliyuncs.com}/plugins/ai-statistics:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/ai-statistics-1.0.0.yaml"
 
   echo -e "\
 apiVersion: extensions.higress.io/v1alpha1
@@ -433,7 +433,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: AUTHN
   priority: 900
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-router:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/model-router.internal.yaml"
+  url: oci://${PLUGIN_REGISTRY:-higress-registry.cn-hangzhou.cr.aliyuncs.com}/plugins/model-router:2.0.0" >"$WASM_PLUGIN_CONFIG_FOLDER/model-router.internal.yaml"
 }
 
 function appendAiProxyConfigs() {

--- a/all-in-one/scripts/config-template/ai-proxy.sh
+++ b/all-in-one/scripts/config-template/ai-proxy.sh
@@ -125,7 +125,7 @@ spec:
   failStrategy: FAIL_OPEN
   phase: UNSPECIFIED_PHASE
   priority: \"100\"
-  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0" > "$WASM_PLUGIN_CONFIG_FILE"
+  url: oci://${PLUGIN_REGISTRY:-higress-registry.cn-hangzhou.cr.aliyuncs.com}/plugins/ai-proxy:2.0.0" > "$WASM_PLUGIN_CONFIG_FILE"
 }
 
 function initializeMcpBridge() {


### PR DESCRIPTION
## Summary

Auto-detect timezone and select the geographically closest plugin registry for faster WASM plugin downloads.

## Problem

Currently, all plugin OCI URLs are hardcoded to use the Hangzhou registry (`higress-registry.cn-hangzhou.cr.aliyuncs.com`), which causes slow downloads for users in other regions.

## Solution

**Auto-detect timezone and select optimal registry:**

| Region | Timezone Examples | Selected Registry |
|--------|------------------|-------------------|
| China & nearby | Asia/Shanghai, Asia/Hong_Kong, etc. | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |
| Southeast Asia | Asia/Singapore, Asia/Jakarta, etc. | `higress-registry.ap-southeast-7.cr.aliyuncs.com` |
| North America | America/*, US/*, Canada/* | `higress-registry.us-west-1.cr.aliyuncs.com` |
| Others | Default fallback | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |

## Changes

### 1. Script Updates (`get-ai-gateway.sh`)

**Add `detectPluginRegistry()` function:**
- Detects timezone using `timedatectl` or `/etc/timezone`
- Selects optimal registry based on geographic region
- Supports manual override via `PLUGIN_REGISTRY` environment variable
- Prints selected registry for visibility

**Add `DEFAULT_PLUGIN_REGISTRY` constant:**
- Defaults to Hangzhou registry
- Used as fallback when auto-detection fails

**Update `resetEnv()` function:**
- Calls `detectPluginRegistry()` during initialization
- Sets `PLUGIN_REGISTRY` variable

**Update config file generation:**
- Write `PLUGIN_REGISTRY` to `default.cfg`
- Makes registry available to container scripts

### 2. Template Updates

**`scripts/config-template/ai-gateway.sh`:**
- Replace hardcoded `oci://higress-registry.cn-hangzhou.cr.aliyuncs.com` with `oci://${PLUGIN_REGISTRY:-higress-registry.cn-hangzhou.cr.aliyuncs.com}`
- Applies to:
  - `ai-proxy` plugin
  - `ai-statistics` plugin  
  - `model-router` plugin

**`scripts/config-template/ai-proxy.sh`:**
- Replace hardcoded `ai-proxy` plugin URL with variable

## Usage

**Auto-detection (default):**
```bash
./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx
# Output:
# Auto-detected timezone: Asia/Shanghai
# Selected plugin registry: higress-registry.cn-hangzhou.cr.aliyuncs.com
```

**Manual override:**
```bash
PLUGIN_REGISTRY="higress-registry.ap-southeast-7.cr.aliyuncs.com" \
  ./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx
```

## Benefits

- **Faster plugin downloads** in non-China regions
- **Transparent** - auto-detects without user intervention
- **Flexible** - supports manual override
- **Visible** - prints selected registry to console
- **Backward compatible** - defaults to Hangzhou registry if detection fails

## Testing

- [x] Script syntax validation (`bash -n`)
- [x] Auto-detection logic for different timezones
- [x] Manual override via `PLUGIN_REGISTRY` env var
- [x] Plugin URL substitution in all templates

## Related

Improves deployment experience for the higress-clawdbot-integration skill, which currently documents manual `IMAGE_REPO` selection for the all-in-one container image. Now plugins also benefit from the same geographic optimization.