### PR TITLE
fix: reuse PLUGIN_REGISTRY for IMAGE_REPO construction

### DIFF
--- a/all-in-one/get-ai-gateway.sh
+++ b/all-in-one/get-ai-gateway.sh
@@ -562,12 +562,15 @@ resetEnv() {
   DATA_FOLDER="$ROOT"
   CONTAINER_NAME="${CONTAINER_NAME:-$DEFAULT_CONTAINER_NAME}"
 
-  IMAGE_REPO="${IMAGE_REPO:-$DEFAULT_IMAGE_REPO}"
-  IMAGE_TAG="${IMAGE_TAG:-$DEFAULT_IMAGE_TAG}"
-  
-  # Detect and set plugin registry if not already set
+  # Detect and set plugin registry first (before IMAGE_REPO)
   detectPluginRegistry
   PLUGIN_REGISTRY="${PLUGIN_REGISTRY:-$DEFAULT_PLUGIN_REGISTRY}"
+  
+  # Build IMAGE_REPO from PLUGIN_REGISTRY if not explicitly set
+  if [ -z "$IMAGE_REPO" ]; then
+    IMAGE_REPO="${PLUGIN_REGISTRY}/higress/all-in-one"
+  fi
+  IMAGE_TAG="${IMAGE_TAG:-$DEFAULT_IMAGE_TAG}"
 
   GATEWAY_HTTP_PORT="${GATEWAY_HTTP_PORT:-$DEFAULT_GATEWAY_HTTP_PORT}"
   GATEWAY_HTTPS_PORT="${GATEWAY_HTTPS_PORT:-$DEFAULT_GATEWAY_HTTPS_PORT}"


### PR DESCRIPTION
## Problem

After #239, `IMAGE_REPO` and `PLUGIN_REGISTRY` are set independently, which means:
- Duplicate registry domain logic
- Potential inconsistency (could use different registries)
- Violates DRY principle

## Solution

**Reuse `PLUGIN_REGISTRY` when constructing `IMAGE_REPO`:**

```bash
# Before (in resetEnv):
IMAGE_REPO="${IMAGE_REPO:-$DEFAULT_IMAGE_REPO}"
detectPluginRegistry
PLUGIN_REGISTRY="${PLUGIN_REGISTRY:-$DEFAULT_PLUGIN_REGISTRY}"

# After:
detectPluginRegistry
PLUGIN_REGISTRY="${PLUGIN_REGISTRY:-$DEFAULT_PLUGIN_REGISTRY}"

if [ -z "$IMAGE_REPO" ]; then
  IMAGE_REPO="${PLUGIN_REGISTRY}/higress/all-in-one"
fi
```

## Changes

1. **Reorder in `resetEnv()`:**
   - Detect `PLUGIN_REGISTRY` first
   - Then construct `IMAGE_REPO` from it

2. **Conditional IMAGE_REPO construction:**
   - If `IMAGE_REPO` explicitly set → use it (backward compatible)
   - If not set → build from `PLUGIN_REGISTRY`

## Benefits

✅ **Single source of truth** - Registry domain only detected once  
✅ **Guaranteed consistency** - Container image and plugins always use same registry  
✅ **DRY principle** - No duplicate timezone → registry mapping logic  
✅ **Backward compatible** - Users can still override `IMAGE_REPO` explicitly

## Example Behavior

**Auto-detection (typical):**
```bash
./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx
# Output:
# Auto-detected timezone: Asia/Singapore
# Selected plugin registry: higress-registry.ap-southeast-7.cr.aliyuncs.com
#
# Both will use: higress-registry.ap-southeast-7.cr.aliyuncs.com
# - IMAGE_REPO: higress-registry.ap-southeast-7.cr.aliyuncs.com/higress/all-in-one
# - PLUGIN_REGISTRY: higress-registry.ap-southeast-7.cr.aliyuncs.com
```

**Explicit override (advanced):**
```bash
IMAGE_REPO="custom-registry.example.com/my-higress:latest" \
  ./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx
# IMAGE_REPO: custom-registry.example.com/my-higress:latest (user override)
# PLUGIN_REGISTRY: higress-registry.cn-hangzhou.cr.aliyuncs.com (auto-detected)
```

**Partial override (typical):**
```bash
PLUGIN_REGISTRY="higress-registry.us-west-1.cr.aliyuncs.com" \
  ./get-ai-gateway.sh start --non-interactive --dashscope-key sk-xxx
# IMAGE_REPO: higress-registry.us-west-1.cr.aliyuncs.com/higress/all-in-one (derived)
# PLUGIN_REGISTRY: higress-registry.us-west-1.cr.aliyuncs.com (user override)
```

## Testing

- [x] Script syntax validation (`bash -n`)
- [x] IMAGE_REPO derived from PLUGIN_REGISTRY when not set
- [x] Explicit IMAGE_REPO override still works
- [x] Both variables use same registry domain in default case

## Related

- Improves: #239 (auto-select plugin registry)