### PR TITLE
feat: protect Standalone release sync

### DIFF
--- a/.github/workflows/sync-higress-release.yaml
+++ b/.github/workflows/sync-higress-release.yaml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   render:
     runs-on: ubuntu-latest
+    # STANDALONE_RELEASE_APP_PRIVATE_KEY is scoped to this protected environment.
+    environment: standalone-release-sync
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

- Bind the exact Higress release receiver to the protected `standalone-release-sync` Environment.
- Preserve existing immutable input verification, deterministic branch naming, idempotency, and dry-run behavior.

## Validation

- `actionlint .github/workflows/sync-higress-release.yaml`
- YAML and shell syntax checks
- `git diff --check`

## Traceability

- Design: https://github.com/higress-group/higress/issues/4442
- TASK-4442010: https://github.com/higress-group/higress/issues/4442#issuecomment-5266749068

## Agent-assisted contribution

This PR was implemented with Codex assistance and independently reviewed before submission.