### PR TITLE
fix: align ORAS setup action with CLI pin

### DIFF
--- a/.github/workflows/sync-higress-release.yaml
+++ b/.github/workflows/sync-higress-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           token: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Validate immutable event and independently resolve upstreams

--- a/tools/test_release_evidence.py
+++ b/tools/test_release_evidence.py
@@ -1,3 +1,4 @@
+import pathlib
 import unittest
 from release_evidence import derive_pins, evidence_hash, validate, verify_resolved_image
 
@@ -49,6 +50,12 @@ class EvidenceTest(unittest.TestCase):
         bad = dict(expected); bad["annotationsByPlatform"] = {"linux/amd64": {}}
         with self.assertRaisesRegex(ValueError, "provenance"):
             verify_resolved_image(expected, bad)
+
+    def test_release_receiver_pairs_oras_setup_metadata_with_pinned_cli(self):
+        workflow = (pathlib.Path(__file__).resolve().parents[1] / ".github/workflows/sync-higress-release.yaml").read_text(encoding="utf-8")
+        self.assertNotIn("oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93", workflow)
+        self.assertEqual(1, workflow.count("version: 1.2.3"))
+        self.assertEqual(1, workflow.count("oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3\n        with:\n          version: 1.2.3"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Pin the exact-release receiver to setup action metadata that supports its existing ORAS CLI 1.2.3 declaration.
- Add a receiver contract test to prevent the mismatch from returning.

## Validation

- `PYTHONPATH=tools python3 tools/test_release_evidence.py` (7 passing)
- actionlint v1.7.7 for the modified workflow
- YAML/static assertions and `git diff --check`

## Traceability

- Design: https://github.com/higress-group/higress/issues/4442
- TASK-4442013: https://github.com/higress-group/higress/issues/4442#issuecomment-5267888225

## Agent-assisted contribution

Implemented with Codex assistance and independently reviewed. No release or registry behavior changed.