### PR TITLE
fix: verify release images with ORAS 1.2

### DIFF
--- a/.github/workflows/sync-higress-release.yaml
+++ b/.github/workflows/sync-higress-release.yaml
@@ -70,8 +70,50 @@ jobs:
           jq -cS '[.plugins[] | select(.consumers.console != null) | {key:.consumers.console.propertyKey,resourceDir:.consumers.console.resourceDir,version,ociRef:("oci://" + .ociRef),digest}] | sort_by(.key)' /tmp/snapshot.json >/tmp/snapshot-console-map.json
           jq -cS '[.pluginLock.plugins | to_entries[] | {key:.key,resourceDir:.value.resourceDir,version:.value.version,ociRef:.value.ociRef,digest:.value.digest}] | sort_by(.key)' /tmp/console-provenance.json >/tmp/console-map.json
           cmp /tmp/snapshot-console-map.json /tmp/console-map.json
-          verify_plugin_server() { expected=$(jq -c .pluginServer /tmp/release.json); ref=$(jq -r .ref <<<"$expected"); digest=$(jq -r .digest <<<"$expected"); test "$(oras manifest fetch "$ref" --descriptor --format json | jq -r .digest)" = "$digest"; oras manifest fetch "$ref@$digest" --raw >/tmp/index.json; platforms=$(jq -c '[.manifests[] | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json); labels='{}'; while IFS=$'\t' read -r child platform; do manifest=$(oras manifest fetch "$ref@$child"); config=$(jq -r .config.digest <<<"$manifest"); value=$(oras blob fetch "$ref@$child" "$config" -o - | jq -c '.config.Labels // {}'); labels=$(jq --arg platform "$platform" --argjson value "$value" '.[$platform]=$value' <<<"$labels"); done < <(jq -r '.manifests[] | [.digest, (.platform.os + "/" + .platform.architecture)] | @tsv' /tmp/index.json); jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson labels "$labels" '{ref:$ref,digest:$digest,platforms:$platforms,labelsByPlatform:$labels}' >/tmp/resolved.json; PYTHONPATH=tools python3 -c 'import json; from release_evidence import verify_resolved_image; verify_resolved_image(json.load(open("/tmp/release.json"))["pluginServer"],json.load(open("/tmp/resolved.json")))'; }
-          verify_gateway_image() { name=$1; expected=$(jq -c --arg name "$name" '.gatewayImages[$name]' /tmp/release.json); ref=$(jq -r .ref <<<"$expected"); digest=$(jq -r .digest <<<"$expected"); test "$(oras manifest fetch "$ref" --descriptor --format json | jq -r .digest)" = "$digest"; oras manifest fetch "$ref@$digest" --raw >/tmp/index.json; platforms=$(jq -c '[.manifests[] | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json); annotations='{}'; while IFS=$'\t' read -r platform value; do annotations=$(jq --arg platform "$platform" --argjson value "$value" '.[$platform]=$value' <<<"$annotations"); done < <(jq -r '.manifests[] | [(.platform.os + "/" + .platform.architecture), ((.annotations // {}) | tojson)] | @tsv' /tmp/index.json); jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson annotations "$annotations" '{ref:$ref,digest:$digest,platforms:$platforms,annotationsByPlatform:$annotations}' >/tmp/resolved.json; PYTHONPATH=tools python3 -c 'import json; from release_evidence import verify_resolved_image; verify_resolved_image(json.load(open("/tmp/release.json"))["gatewayImages"]["'"$name"'"],json.load(open("/tmp/resolved.json")))'; }
+          verify_plugin_server_index() {
+            jq -e '
+              def runnable: (.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"));
+              [.manifests[] | select(runnable)] as $runnable |
+              [.manifests[] | select(runnable | not)] as $extra |
+              (([$runnable[] | .platform.os + "/" + .platform.architecture] | sort) == ["linux/amd64","linux/arm64"]) and
+              (($runnable | length) == 2) and
+              (($extra | length) == 0 or
+                (($extra | length) == 2 and
+                 all($extra[];
+                   .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                   .platform.os == "unknown" and .platform.architecture == "unknown" and
+                   .annotations["vnd.docker.reference.type"] == "attestation-manifest") and
+                 (([$extra[].annotations["vnd.docker.reference.digest"]] | sort) == ([$runnable[].digest] | sort))))
+            ' "$1" >/dev/null
+          }
+          verify_plugin_server() {
+            expected=$(jq -c .pluginServer /tmp/release.json)
+            ref=$(jq -r .ref <<<"$expected"); repo=${ref%:*}; digest=$(jq -r .digest <<<"$expected")
+            test "$(oras manifest fetch "$ref" --descriptor | jq -r .digest)" = "$digest"
+            oras manifest fetch "$repo@$digest" >/tmp/index.json
+            verify_plugin_server_index /tmp/index.json
+            platforms=$(jq -c '[.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json)
+            labels='{}'
+            while IFS=$'\t' read -r child platform; do
+              manifest=$(oras manifest fetch "$repo@$child"); config=$(jq -r .config.digest <<<"$manifest")
+              value=$(oras blob fetch "$repo@$config" -o - | jq -c '.config.Labels // {}')
+              labels=$(jq --arg platform "$platform" --argjson value "$value" '.[$platform]=$value' <<<"$labels")
+            done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | [.digest, (.platform.os + "/" + .platform.architecture)] | @tsv' /tmp/index.json)
+            jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson labels "$labels" '{ref:$ref,digest:$digest,platforms:$platforms,labelsByPlatform:$labels}' >/tmp/resolved.json
+            PYTHONPATH=tools python3 -c 'import json; from release_evidence import verify_resolved_image; verify_resolved_image(json.load(open("/tmp/release.json"))["pluginServer"],json.load(open("/tmp/resolved.json")))'
+          }
+          verify_gateway_image() {
+            name=$1; expected=$(jq -c --arg name "$name" '.gatewayImages[$name]' /tmp/release.json)
+            ref=$(jq -r .ref <<<"$expected"); repo=${ref%:*}; digest=$(jq -r .digest <<<"$expected")
+            test "$(oras manifest fetch "$ref" --descriptor | jq -r .digest)" = "$digest"
+            oras manifest fetch "$repo@$digest" >/tmp/index.json
+            platforms=$(jq -c '[.manifests[] | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json)
+            test "$platforms" = '["linux/amd64","linux/arm64"]'
+            annotations='{}'
+            while IFS=$'\t' read -r platform value; do annotations=$(jq --arg platform "$platform" --argjson value "$value" '.[$platform]=$value' <<<"$annotations"); done < <(jq -r '.manifests[] | [(.platform.os + "/" + .platform.architecture), ((.annotations // {}) | tojson)] | @tsv' /tmp/index.json)
+            jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson annotations "$annotations" '{ref:$ref,digest:$digest,platforms:$platforms,annotationsByPlatform:$annotations}' >/tmp/resolved.json
+            PYTHONPATH=tools python3 -c 'import json; from release_evidence import verify_resolved_image; verify_resolved_image(json.load(open("/tmp/release.json"))["gatewayImages"]["'"$name"'"],json.load(open("/tmp/resolved.json")))'
+          }
           verify_plugin_server; verify_gateway_image controller; verify_gateway_image pilot; verify_gateway_image gateway
           PYTHONPATH=tools python3 -c 'import json; from release_evidence import derive_pins; value=json.load(open("/tmp/release.json")); value.update(derive_pins(value)); json.dump(value,open("/tmp/verified-pins.json","w"),sort_keys=True)'
           plugin=$(jq -r .pluginServer.ref /tmp/release.json); plugin=${plugin##*:}; test "$plugin" = "$(jq -r .gatewayVersion /tmp/release.json)"

--- a/tools/test_release_evidence.py
+++ b/tools/test_release_evidence.py
@@ -57,6 +57,17 @@ class EvidenceTest(unittest.TestCase):
         self.assertEqual(1, workflow.count("version: 1.2.3"))
         self.assertEqual(1, workflow.count("oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3\n        with:\n          version: 1.2.3"))
 
+    def test_release_receiver_uses_oras_12_and_accepts_only_paired_attestations(self):
+        workflow = (pathlib.Path(__file__).resolve().parents[1] / ".github/workflows/sync-higress-release.yaml").read_text(encoding="utf-8")
+        self.assertNotIn("--descriptor --format json", workflow)
+        self.assertNotIn(" --raw", workflow)
+        self.assertNotIn('oras blob fetch "$ref@$child" "$config"', workflow)
+        self.assertIn('oras blob fetch "$repo@$config" -o -', workflow)
+        self.assertIn('verify_plugin_server_index /tmp/index.json', workflow)
+        self.assertIn('.annotations["vnd.docker.reference.type"] == "attestation-manifest"', workflow)
+        self.assertIn('([$extra[].annotations["vnd.docker.reference.digest"]] | sort) == ([$runnable[].digest] | sort)', workflow)
+        self.assertIn('select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"))', workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fix the immutable Higress release receiver for its pinned ORAS 1.2.3 CLI and for standard Buildx provenance attestations on the plugin-server index.

- remove unsupported `manifest fetch --descriptor --format json` and `--raw` forms;
- fetch OCI config blobs with one repository-qualified digest reference;
- accept exactly two runnable plugin-server platforms and either zero attestations or exactly two one-to-one paired Buildx attestation manifests;
- exclude attestations from runnable platform and label resolution;
- keep gateway images strict at exactly `linux/amd64` and `linux/arm64`;
- add regression assertions for all of these contracts.

Related to higress-group/higress#4442 and the Higress 2.2.4 release.

## Verification

Exact head before PR creation: `2eb5546`.

```text
git diff --check
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/sync-higress-release.yaml
PYTHONPATH=tools python3 -m unittest discover -s tools -p 'test_*.py'
```

All passed (9 Python tests). A live anonymous-registry probe of `higress/plugin-server:2.2.4@sha256:05a3e3615434befdb89928e491a8833255733c099dd24faefe82fea4d63165bb` also passed: the index contained the required amd64/arm64 images plus two paired attestations, and both runnable config blobs were fetched with the new syntax and matched gateway version `2.2.4` and snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## Maintainer and AI disclosure

OpenAI Codex materially assisted diagnosis, implementation, testing, and PR preparation. The authenticated PR author is `johnlanni`; live canonical repository permission was checked with `GH_TOKEN` and `GITHUB_TOKEN` unset and returned `role_name=admin`. The author/login match is verified after PR creation. This is a release-blocking receiver correction; immutable release evidence, source, digest, and provenance validation remain mandatory.
