### PR TITLE
fix: verify canonical release evidence hash

### DIFF
--- a/.github/workflows/sync-higress-release.yaml
+++ b/.github/workflows/sync-higress-release.yaml
@@ -37,9 +37,11 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = repository_dispatch ]; then evidence=$(jq -r .evidence <<<"$EVENT"); received_sha=$(jq -r .evidenceSha256 <<<"$EVENT"); received_key=$(jq -r .idempotencyKey <<<"$EVENT"); else evidence="$INPUT"; received_sha=$(printf '%s' "$INPUT" | sha256sum | awk '{print $1}'); received_key=$received_sha; fi
-          printf '%s' "$evidence" | jq -cS . >/tmp/release.json
-          test "$(sha256sum /tmp/release.json | awk '{print $1}')" = "$received_sha"; test "$received_key" = "$received_sha"
+          if [ "$EVENT_NAME" = repository_dispatch ]; then evidence=$(jq -r .evidence <<<"$EVENT"); received_sha=$(jq -r .evidenceSha256 <<<"$EVENT"); received_key=$(jq -r .idempotencyKey <<<"$EVENT"); else evidence="$INPUT"; received_sha=""; received_key=""; fi
+          canonical=$(printf '%s' "$evidence" | PYTHONPATH=tools python3 -c 'import json,sys; from release_evidence import canonical_bytes; sys.stdout.buffer.write(canonical_bytes(json.load(sys.stdin)))')
+          printf '%s' "$canonical" >/tmp/release.json
+          canonical_sha=$(printf '%s' "$canonical" | sha256sum | awk '{print $1}')
+          if [ "$EVENT_NAME" = repository_dispatch ]; then test "$received_sha" = "$canonical_sha"; test "$received_key" = "$canonical_sha"; else received_sha=$canonical_sha; received_key=$canonical_sha; fi
           PYTHONPATH=tools python3 -c 'import json,sys; from release_evidence import validate,evidence_hash; value=json.load(open("/tmp/release.json")); validate(value); assert evidence_hash(value)==sys.argv[1]' "$received_sha"
           jq -e '(.schemaVersion == 1) and (.gatewayVersion|test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and (.higress.releaseId|type == "number") and (.higress.tag|test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) and (.higress.commit|test("^[0-9a-f]{40}$")) and (.snapshot.sha256|test("^[0-9a-f]{64}$")) and (.console.releaseId|type == "number") and (.console.commit|test("^[0-9a-f]{40}$")) and (.console.chartDigest|test("^sha256:[0-9a-f]{64}$")) and (.pluginServer.digest|test("^sha256:[0-9a-f]{64}$"))' /tmp/release.json
           tag=$(jq -r .higress.tag /tmp/release.json); commit=$(jq -r .higress.commit /tmp/release.json)

--- a/tools/test_release_evidence.py
+++ b/tools/test_release_evidence.py
@@ -1,6 +1,6 @@
 import pathlib
 import unittest
-from release_evidence import derive_pins, evidence_hash, validate, verify_resolved_image
+from release_evidence import canonical_bytes, derive_pins, evidence_hash, validate, verify_resolved_image
 
 
 def evidence():
@@ -16,6 +16,8 @@ class EvidenceTest(unittest.TestCase):
         item = evidence()
         self.assertEqual(evidence_hash(item), evidence_hash(dict(reversed(list(item.items())))))
         self.assertEqual(derive_pins(item)["pluginServerDigest"], "sha256:" + "e" * 64)
+        self.assertEqual(canonical_bytes({"z": "雪", "a": 1}), b'{"a":1,"z":"\\u96ea"}')
+        self.assertFalse(canonical_bytes(item).endswith(b"\n"))
 
     def test_rejects_missing_and_drifted_identity(self):
         item = evidence(); item["console"].pop("chartDigest")
@@ -56,6 +58,17 @@ class EvidenceTest(unittest.TestCase):
         self.assertNotIn("oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93", workflow)
         self.assertEqual(1, workflow.count("version: 1.2.3"))
         self.assertEqual(1, workflow.count("oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3\n        with:\n          version: 1.2.3"))
+
+    def test_release_receiver_hashes_no_newline_canonical_json(self):
+        workflow = (pathlib.Path(__file__).resolve().parents[1] / ".github/workflows/sync-higress-release.yaml").read_text(encoding="utf-8")
+        self.assertIn('canonical=$(printf \'%s\' "$evidence" | PYTHONPATH=tools python3', workflow)
+        self.assertIn('from release_evidence import canonical_bytes', workflow)
+        self.assertIn('canonical_bytes(json.load(sys.stdin))', workflow)
+        self.assertIn('printf \'%s\' "$canonical" >/tmp/release.json', workflow)
+        self.assertIn('canonical_sha=$(printf \'%s\' "$canonical" | sha256sum', workflow)
+        self.assertIn('test "$received_sha" = "$canonical_sha"; test "$received_key" = "$canonical_sha"', workflow)
+        self.assertNotIn('jq -cS . >/tmp/release.json', workflow)
+        self.assertNotIn('canonical=$(printf \'%s\' "$evidence" | jq', workflow)
 
     def test_release_receiver_uses_oras_12_and_accepts_only_paired_attestations(self):
         workflow = (pathlib.Path(__file__).resolve().parents[1] / ".github/workflows/sync-higress-release.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Verify release evidence against the exact no-newline canonical JSON bytes used by `tools/release_evidence.py`. The receiver previously wrote `jq -cS` output to a file and hashed jq's trailing newline, then independently asserted the Python no-newline canonical hash, making the two checks impossible to satisfy simultaneously.

The workflow now canonicalizes once, writes and hashes with `printf '%s'`, requires both repository-dispatch hash fields to equal that canonical hash, and derives the hash locally for manual dry-run input. All artifact, release, Console provenance, plugin-server and gateway image checks remain unchanged.

Related to higress-group/higress#4442. Runtime reproduction: https://github.com/higress-group/higress-standalone/actions/runs/31758723380

## Verification

```text
git diff --check
/tmp/actionlint .github/workflows/sync-higress-release.yaml
python3 -m unittest discover -s tools -p 'test_*.py' -v
```

All 10 tests pass at `12076d52a8408a762f74f37bd6223bdedcbbc279`. The Python canonical-byte contract is exercised directly: reordered input and Unicode are normalized with sorted keys and ASCII escaping, no terminal newline is emitted, and the receiver requires both dispatch hash fields to equal the SHA of those exact bytes.

Exact base: `0a58c7c211ada259ee6e17a866c55fef111fad7b`.

## Agent participation

Material AI assistance: OpenAI Codex diagnosed the cross-repository canonical-byte mismatch, implemented the receiver repair and regression test, and coordinated exact-head verification. Maintainer `johnlanni` is the PR author and has live `admin` permission in `higress-group/higress-standalone`; `GH_TOKEN` and `GITHUB_TOKEN` were unset for identity and verification commands. The protected v2.2.4 end-to-end release verification is tracked by Higress Design #4442 / TASK-4442005.